### PR TITLE
added apt-get so packages patched at buld time for docker (fix trivvy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,14 @@ name: CI
 #python script for lcov code coverage for flutter, lcov takes too long as has to download all dependencies. Python filter out generated files, writes lcov.info and checks meet threshhold coverage
 #generated files are already automatically excluded from coverage
 
+
+# --pull forces Docker to grab the latest base image layer instead of
+  # reusing a cached one, so security updates flow through on every build.
+
+#to do
 #to setup cd.yml still 
+#add actions/cashe for docker 
+#fix python mutable tag by adding dependabot
 
 
 on:
@@ -367,7 +374,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build \
+          docker build --pull\
             -f ${{ matrix.dockerfile }} \
             -t ${{ matrix.image }}:${{ github.sha }} \
             .

--- a/infrastructure/Dockerfile.backend
+++ b/infrastructure/Dockerfile.backend
@@ -34,9 +34,12 @@ RUN ./mvnw package -DskipTests --no-transfer-progress && \
 # Minimal JRE only 
 FROM eclipse-temurin:21-jre-jammy AS runtime
 
-# curl is not present in the base JRE image, required for the HEALTHCHECK below
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
+# Apply latest Ubuntu security patches and install curl (required for the HEALTHCHECK) in the same layer so Trivy doesn't flag stale OS packages.
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user, if container escape occurs, attacker does not get root.
 RUN groupadd --system mealchemy && \

--- a/infrastructure/Dockerfile.engine
+++ b/infrastructure/Dockerfile.engine
@@ -29,6 +29,14 @@ RUN mkdir -p /install && pip install --no-cache-dir --prefix=/install -r require
 # python:3.12.3-slim-bookworm
 FROM python:3.12-slim-bookworm AS runtime
 
+
+# Apply latest Debian security patches so Trivy doesn't flag stale OS
+#packages  into the base image (libc-bin, libcap2, libsystemd0, etc).
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Prevent .pyc files and ensure stdout/stderr are not buffered in the container
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1


### PR DESCRIPTION
**Dockerfile.engine:** 
added apt-get update && apt-get upgrade -y step at the start of the runtime stage (builder stage doesn't ship to the final image, so it's not patched).

**Dockerfile.backend:** 
folded apt-get upgrade into the existing apt layer that installs curl

**ci.yml:** 
docker build --pull ensures the base image layer is always re-fetched on PRs, so security updates flow through automatically.
