### PR TITLE
Feature/component additions/sofia finlayson

### DIFF
--- a/frontend/lib/core/routes/app_router.dart
+++ b/frontend/lib/core/routes/app_router.dart
@@ -6,10 +6,11 @@ import '../../features/dashboard/screens/dashboard_screen.dart';
 import '../../features/pantry/screens/pantry_screen.dart';
 import '../../features/preference/screens/preference_screen.dart';
 import '../../features/vault/screens/vault_screen.dart';
+import '../../features/pantry/screens/add_ingredient_screen.dart';
 
 
 final appRouter = GoRouter(
-  initialLocation: AppRoutes.login, // Sets the first screen shown when the app launches. 
+  initialLocation: AppRoutes.pantry, // Sets the first screen shown when the app launches. 
                                     // During development: change this to your screen (e.g. AppRoutes.pantry)
                                     // Before committing: ALWAYS reset this back to AppRoutes.login
   routes: [
@@ -32,6 +33,10 @@ final appRouter = GoRouter(
     GoRoute(
       path: AppRoutes.vault,
       builder: (context, state) => const VaultScreen(),
+    ),
+    GoRoute(
+      path: AppRoutes.addIngredient,
+      builder: (context, state) => const AddIngredientScreen(),
     ),
   ],
 );

--- a/frontend/lib/core/routes/app_routes.dart
+++ b/frontend/lib/core/routes/app_routes.dart
@@ -7,4 +7,5 @@ class AppRoutes {
   static const String vault = '/vault';
   static const String preference = '/preference';
   static const String profile    = '/profile';
+  static const String addIngredient = '/pantry/add';
 }

--- a/frontend/lib/core/shared_widgets/Molecules/app_search_bar.dart
+++ b/frontend/lib/core/shared_widgets/Molecules/app_search_bar.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../atoms/app_text_field.dart';
+
+//search input
+class AppSearchBar extends StatelessWidget {
+  const AppSearchBar({
+    super.key,
+    this.controller,
+    this.hint = 'Search...',
+    this.onChanged,
+    this.onSubmitted,
+    this.onClear,
+  });
+
+  final TextEditingController? controller;
+  final String hint;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final VoidCallback? onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppTextField(
+      controller: controller,
+      hint: hint,
+      prefixIcon: Icons.search,
+      suffixIcon: onClear == null
+          ? null
+          : IconButton(
+              onPressed: onClear,
+              icon: const Icon(Icons.close),
+              tooltip: 'Clear search',
+            ),
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+    );
+  }
+}

--- a/frontend/lib/core/shared_widgets/Molecules/app_section_header.dart
+++ b/frontend/lib/core/shared_widgets/Molecules/app_section_header.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colours.dart';
+import '../../theme/app_typography.dart';
+
+class AppSectionHeader extends StatelessWidget {
+  const AppSectionHeader({
+    super.key,
+    required this.title,
+    this.trailing,
+    this.showAccentLine = true,
+  });
+
+  final String title;
+  final String? trailing;
+  final bool showAccentLine;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        if (showAccentLine) ...[
+          Container(width: 2, height: 18, color: AppColors.primary),
+          const SizedBox(width: 12),
+        ],
+        Text(
+          title,
+          style: AppTextStyles.body.copyWith(
+            color: AppColors.primary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        if (trailing != null) ...[
+          const Spacer(),
+          Text(
+            trailing!,
+            style: AppTextStyles.bodySmall.copyWith(
+              color: AppColors.textMuted,
+              letterSpacing: 0.5,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/frontend/lib/core/shared_widgets/Organisms/app_filter_bar.dart
+++ b/frontend/lib/core/shared_widgets/Organisms/app_filter_bar.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import '../atoms/app_chip.dart';
+
+//label and count for filtering
+class AppFilterOption {
+  const AppFilterOption({
+    required this.label,
+    this.count,
+  });
+
+  final String label;
+  final int? count;
+}
+
+//horizontal filter
+class AppFilterBar extends StatelessWidget {
+  const AppFilterBar({
+    super.key,
+    required this.options,
+    required this.selectedIndex,
+    required this.onSelected,
+  });
+
+  final List<AppFilterOption> options;
+  final int selectedIndex;
+  final ValueChanged<int> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: List.generate(options.length, (index) {
+          final option = options[index];
+          final selected = index == selectedIndex;
+          final label = option.count == null
+              ? option.label
+              : '${option.label}  ${option.count}';
+
+          return Padding(
+            padding: EdgeInsets.only(
+              right: index == options.length - 1 ? 0 : 8,
+            ),
+            child: AppChip(
+              label: label,
+              selected: selected,
+              onTap: () => onSelected(index),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/frontend/lib/core/shared_widgets/Organisms/app_navbar.dart
+++ b/frontend/lib/core/shared_widgets/Organisms/app_navbar.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+
+import '../../routes/app_routes.dart';
+import '../../theme/app_colours.dart';
+import '../../theme/app_typography.dart';
+
+//bottom nav
+class AppNavItem {
+  const AppNavItem({
+    required this.label,
+    required this.icon,
+    required this.route,
+  });
+
+  final String label;
+  final IconData icon;
+  final String route;
+}
+
+//shared bottom nav for the app screens
+class AppNavbar extends StatelessWidget {
+  const AppNavbar({
+    super.key,
+    required this.currentRoute,
+    required this.onRouteSelected,
+    this.items = defaultItems,
+  });
+
+  final String currentRoute;
+  final ValueChanged<String> onRouteSelected;
+  final List<AppNavItem> items;
+
+  static const List<AppNavItem> defaultItems = [
+    AppNavItem(
+      label: 'Discover',
+      icon: Icons.explore_outlined,
+      route: AppRoutes.dashboard,
+    ),
+    AppNavItem(
+      label: 'Vault',
+      icon: Icons.bookmark_border,
+      route: AppRoutes.vault,
+    ),
+    AppNavItem(
+      label: 'Pantry',
+      icon: Icons.kitchen_outlined,
+      route: AppRoutes.pantry,
+    ),
+    AppNavItem(
+      label: 'Profile',
+      icon: Icons.person_outline,
+      route: AppRoutes.preference,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppColors.surfaceLight,
+          border: Border(
+            top: BorderSide(
+              color: AppColors.divider.withValues(alpha: 0.7),
+            ),
+          ),
+        ),
+        child: Row(
+          children: items.map((item) {
+            final selected = item.route == currentRoute;
+
+            return Expanded(
+              child: _NavbarButton(
+                item: item,
+                selected: selected,
+                onTap: () => onRouteSelected(item.route),
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+}
+
+class _NavbarButton extends StatelessWidget {
+  const _NavbarButton({
+    required this.item,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final AppNavItem item;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = selected ? AppColors.primary : AppColors.textMuted;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(14),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 180),
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: selected
+                    ? AppColors.primary.withValues(alpha: 0.12)
+                    : Colors.transparent,
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Icon(item.icon, color: color, size: 22),
+            ),
+            const SizedBox(height: 3),
+            Text(
+              item.label.toUpperCase(),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTextStyles.label.copyWith(
+                color: color,
+                fontSize: 9,
+                letterSpacing: 0.7,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/core/shared_widgets/atoms/app_button.dart
+++ b/frontend/lib/core/shared_widgets/atoms/app_button.dart
@@ -1,1 +1,110 @@
 //main action buttons used across screens
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colours.dart';
+import '../../theme/app_typography.dart';
+
+//button styles
+enum AppButtonVariant {
+  primary,
+  outline,
+  text,
+}
+
+class AppButton extends StatelessWidget {
+  const AppButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.variant = AppButtonVariant.primary,
+    this.icon,
+    this.fullWidth = true,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final AppButtonVariant variant;
+  final IconData? icon;
+  final bool fullWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    //building matching material button
+    final button = switch (variant) {
+      AppButtonVariant.primary => ElevatedButton(
+          onPressed: onPressed,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: AppColors.textDark,
+            padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 15),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(2),
+            ),
+            textStyle: AppTextStyles.button,
+          ),
+          child: _ButtonContent(label: label, icon: icon),
+        ),
+      AppButtonVariant.outline => OutlinedButton(
+          onPressed: onPressed,
+          style: OutlinedButton.styleFrom(
+            foregroundColor: AppColors.primary,
+            side: const BorderSide(color: AppColors.accent),
+            padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 15),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(2),
+            ),
+            textStyle: AppTextStyles.button,
+          ),
+          child: _ButtonContent(label: label, icon: icon),
+        ),
+      AppButtonVariant.text => TextButton(
+          onPressed: onPressed,
+          style: TextButton.styleFrom(
+            foregroundColor: AppColors.primary,
+            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+            textStyle: AppTextStyles.button,
+          ),
+          child: _ButtonContent(label: label, icon: icon),
+        ),
+    };
+
+    if (!fullWidth) {
+      return button;
+    }
+
+    return SizedBox(
+      width: double.infinity,
+      child: button,
+    );
+  }
+}
+
+//consistent icons and labels
+class _ButtonContent extends StatelessWidget {
+  const _ButtonContent({
+    required this.label,
+    this.icon,
+  });
+
+  final String label;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(label.toUpperCase());
+
+    if (icon == null) {
+      return text;
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(icon, size: 18),
+        const SizedBox(width: 8),
+        text,
+      ],
+    );
+  }
+}

--- a/frontend/lib/core/shared_widgets/atoms/app_chip.dart
+++ b/frontend/lib/core/shared_widgets/atoms/app_chip.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colours.dart';
+import '../../theme/app_typography.dart';
+
+class AppChip extends StatelessWidget {
+  const AppChip({
+    super.key,
+    required this.label,
+    this.selected = false,
+    this.onTap,
+    this.onRemove,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback? onTap;
+  final VoidCallback? onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = selected ? AppColors.primary : AppColors.surfaceLight;
+    final foregroundColor = selected ? AppColors.textDark : AppColors.textLight;
+    final borderColor = selected ? AppColors.primary : AppColors.divider;
+
+    return Material(
+      color: backgroundColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: borderColor),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+            14,
+            10,
+            onRemove == null ? 14 : 10,
+            10,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label,
+                style: AppTextStyles.label.copyWith(
+                  color: foregroundColor,
+                  letterSpacing: 0.6,
+                ),
+              ),
+              if (onRemove != null) ...[
+                const SizedBox(width: 8),
+                GestureDetector(
+                  onTap: onRemove,
+                  child: Icon(
+                    Icons.close,
+                    size: 14,
+                    color: foregroundColor,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/core/shared_widgets/atoms/app_text_field.dart
+++ b/frontend/lib/core/shared_widgets/atoms/app_text_field.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colours.dart';
+import '../../theme/app_typography.dart';
+
+//shared styles for the text inputs
+class AppTextField extends StatelessWidget {
+  const AppTextField({
+    super.key,
+    this.controller,
+    this.label,
+    this.hint,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.keyboardType,
+    this.onChanged,
+    this.onSubmitted,
+    this.maxLines = 1,
+    this.enabled = true,
+  });
+
+  final TextEditingController? controller;
+  final String? label;
+  final String? hint;
+  final IconData? prefixIcon;
+  final Widget? suffixIcon;
+  final TextInputType? keyboardType;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final int maxLines;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      enabled: enabled,
+      keyboardType: keyboardType,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      maxLines: maxLines,
+      style: AppTextStyles.body.copyWith(color: AppColors.textLight),
+      //uses app theme tokens for consistent inputs
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        //search and form inputs support
+        prefixIcon: prefixIcon == null
+            ? null
+            : Icon(prefixIcon, color: AppColors.textMuted),
+        suffixIcon: suffixIcon,
+        labelStyle: AppTextStyles.bodySmall.copyWith(
+          color: AppColors.textMuted,
+        ),
+        hintStyle: AppTextStyles.body.copyWith(
+          color: AppColors.textMuted,
+          fontStyle: FontStyle.italic,
+        ),
+        filled: true,
+        fillColor: AppColors.bgLight,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 14,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(2),
+          borderSide: const BorderSide(color: AppColors.divider),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(2),
+          borderSide: const BorderSide(color: AppColors.divider),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(2),
+          borderSide: const BorderSide(
+            color: AppColors.primary,
+            width: 1.4,
+          ),
+        ),
+        disabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(2),
+          borderSide: BorderSide(
+            color: AppColors.divider.withValues(alpha: 0.6),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/pantry/screens/add_ingredient_screen.dart
+++ b/frontend/lib/features/pantry/screens/add_ingredient_screen.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/shared_widgets/atoms/app_button.dart';
+import '../../../core/shared_widgets/atoms/app_text_field.dart';
+import '../../../core/shared_widgets/Molecules/app_section_header.dart';
+import '../../../core/theme/app_colours.dart';
+import '../../../core/theme/app_typography.dart';
+
+class AddIngredientScreen extends StatelessWidget {
+  const AddIngredientScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    //temporary form values until API connected
+    final categories = [
+      'produce',
+      'dairy',
+      'meat',
+      'poultry',
+      'seafood',
+      'grains',
+      'legumes',
+      'spices',
+      'condiments',
+      'beverages',
+      'frozen',
+      'snacks',
+      'other',
+    ];
+
+    return Scaffold(
+      backgroundColor: AppColors.bgLight,
+      appBar: AppBar(
+        leading: IconButton(
+          onPressed: () => context.pop(),
+          icon: const Icon(Icons.arrow_back),
+          tooltip: 'Back',
+        ),
+        title: const Text('Add Ingredient'),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 18, 20, 28),
+          children: [
+            Text(
+              'PANTRY ENTRY',
+              style: AppTextStyles.label.copyWith(
+                color: AppColors.primary,
+                letterSpacing: 1.1,
+              ),
+            ),
+            const SizedBox(height: 14),
+            Text(
+              'Add Ingredient\nManually',
+              style: AppTextStyles.heading1.copyWith(
+                color: AppColors.primary,
+                height: 1.05,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Capture the ingredient details you have on hand. This will later help Mealchemy match recipes to your pantry.',
+              style: AppTextStyles.body.copyWith(
+                color: AppColors.textMuted,
+                height: 1.55,
+              ),
+            ),
+            const SizedBox(height: 32),
+            //ingredients
+            const AppSectionHeader(title: 'Ingredient Details'),
+            const SizedBox(height: 14),
+            AppTextField(
+              label: 'Ingredient name',
+              hint: 'e.g. Chicken breast',
+              onChanged: (_) {},
+            ),
+            const SizedBox(height: 14),
+            _CategorySelector(categories: categories),
+            const SizedBox(height: 28),
+            const AppSectionHeader(title: 'Quantity'),
+            const SizedBox(height: 14),
+            Row(
+              children: [
+                Expanded(
+                  child: AppTextField(
+                    label: 'Quantity',
+                    hint: 'e.g. 800',
+                    keyboardType: TextInputType.number,
+                    onChanged: (_) {},
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: AppTextField(
+                    label: 'Unit',
+                    hint: 'g, ml, cups',
+                    onChanged: (_) {},
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 28),
+            const AppSectionHeader(title: 'Purchase Info'),
+            const SizedBox(height: 14),
+            AppTextField(
+              label: 'Price paid',
+              hint: 'e.g. 89.99',
+              keyboardType: TextInputType.number,
+              prefixIcon: Icons.payments_outlined,
+              onChanged: (_) {},
+            ),
+            const SizedBox(height: 28),
+            _StockToggle(
+              value: false,
+              onChanged: (_) {},
+            ),
+            const SizedBox(height: 36),
+            AppButton(
+              label: 'Save Ingredient',
+              icon: Icons.check,
+              onPressed: () {},
+            ),
+            const SizedBox(height: 14),
+            AppButton(
+              label: 'Cancel',
+              variant: AppButtonVariant.outline,
+              onPressed: () => context.pop(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CategorySelector extends StatelessWidget {
+  const _CategorySelector({required this.categories});
+
+  final List<String> categories;
+
+  @override
+  Widget build(BuildContext context) {
+    const selectedCategory = 'produce';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Category',
+          style: AppTextStyles.bodySmall.copyWith(
+            color: AppColors.textMuted,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: categories.map((category) {
+            final selected = category == selectedCategory;
+
+            return ChoiceChip(
+              label: Text(category.toUpperCase()),
+              selected: selected,
+              onSelected: (_) {},
+              selectedColor: AppColors.primary,
+              backgroundColor: AppColors.surfaceLight,
+              labelStyle: AppTextStyles.label.copyWith(
+                color: selected ? AppColors.textDark : AppColors.textLight,
+                letterSpacing: 0.5,
+              ),
+              side: BorderSide(
+                color: selected ? AppColors.primary : AppColors.divider,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _StockToggle extends StatelessWidget {
+  const _StockToggle({
+    required this.value,
+    required this.onChanged,
+  });
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      value: value,
+      onChanged: onChanged,
+      activeThumbColor: AppColors.primary,
+      contentPadding: EdgeInsets.zero,
+      title: Text(
+        'Mark as out of stock',
+        style: AppTextStyles.body.copyWith(
+          color: AppColors.textLight,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: Text(
+        'Use this when the item should stay listed but not count as available.',
+        style: AppTextStyles.bodySmall.copyWith(
+          color: AppColors.textMuted,
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/pantry/screens/pantry_screen.dart
+++ b/frontend/lib/features/pantry/screens/pantry_screen.dart
@@ -1,13 +1,154 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/routes/app_routes.dart';
+import '../../../core/shared_widgets/Molecules/app_search_bar.dart';
+import '../../../core/shared_widgets/Molecules/app_section_header.dart';
+import '../../../core/shared_widgets/Organisms/app_filter_bar.dart';
+import '../../../core/shared_widgets/Organisms/app_navbar.dart';
+import '../../../core/theme/app_colours.dart';
+import '../../../core/theme/app_typography.dart';
+import '../widgets/pantry_item_card.dart';
+import '../widgets/pantry_summary_card.dart';
 
 class PantryScreen extends StatelessWidget {
   const PantryScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    //temp mock data until pantry API connected
+    final filterOptions = [
+      const AppFilterOption(label: 'All', count: 42),
+      const AppFilterOption(label: 'Proteins', count: 2),
+      const AppFilterOption(label: 'Vegetables', count: 2),
+      const AppFilterOption(label: 'Dairy', count: 2),
+    ];
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Pantry')),
-      body: const Center(child: Text('Pantry Screen')),
+      backgroundColor: AppColors.bgLight,
+      appBar: AppBar(
+        title: const Text('Pantry'),
+        actions: [
+          IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.qr_code_scanner_outlined),
+            tooltip: 'Scan ingredient',
+          ),
+          IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.more_vert),
+            tooltip: 'More options',
+          ),
+        ],
+      ),
+      bottomNavigationBar: AppNavbar(
+        currentRoute: AppRoutes.pantry,
+        onRouteSelected: (route) => context.go(route),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {},
+        backgroundColor: AppColors.primary,
+        foregroundColor: AppColors.textDark,
+        child: const Icon(Icons.add),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 10, 20, 28),
+          children: [
+            AppSearchBar(
+              hint: 'Search pantry...',
+              onChanged: (_) {},
+              onClear: () {},
+            ),
+            const SizedBox(height: 18),
+            Text(
+              'Pantry',
+              style: AppTextStyles.heading1.copyWith(
+                color: AppColors.primary,
+              ),
+            ),
+            const SizedBox(height: 16),
+            AppFilterBar(
+              options: filterOptions,
+              selectedIndex: 0,
+              onSelected: (_) {},
+            ),
+            const SizedBox(height: 22),
+            const PantrySummaryCard(
+              totalItems: 42,
+              freshnessPercent: 84,
+              categoryCount: 6,
+              optimizationPercent: 72,
+            ),
+            const SizedBox(height: 26),
+            const AppSectionHeader(
+              title: 'Items',
+              trailing: '42 ITEMS',
+              showAccentLine: false,
+            ),
+            const SizedBox(height: 18),
+            const AppSectionHeader(
+              title: 'Proteins',
+              trailing: '2 ITEMS',
+              showAccentLine: false,
+            ),
+            const SizedBox(height: 10),
+            PantryItemCard(
+              name: 'Chicken Breast',
+              details: '800g • Refrigerated',
+              status: PantryItemStatus.fresh,
+              onEdit: () {},
+            ),
+            const SizedBox(height: 12),
+            PantryItemCard(
+              name: 'Salmon Fillet',
+              details: '150g • Use by tomorrow',
+              status: PantryItemStatus.low,
+              onEdit: () {},
+            ),
+            const SizedBox(height: 22),
+            const AppSectionHeader(
+              title: 'Vegetables',
+              trailing: '2 ITEMS',
+              showAccentLine: false,
+            ),
+            const SizedBox(height: 10),
+            PantryItemCard(
+              name: 'Cherry Tomatoes',
+              details: '~10 pcs • Pantry',
+              status: PantryItemStatus.low,
+              onEdit: () {},
+            ),
+            const SizedBox(height: 12),
+            PantryItemCard(
+              name: 'Baby Spinach',
+              details: '200g • Expired 2 days ago',
+              status: PantryItemStatus.expired,
+              onDelete: () {},
+            ),
+            const SizedBox(height: 22),
+            const AppSectionHeader(
+              title: 'Dairy',
+              trailing: '2 ITEMS',
+              showAccentLine: false,
+            ),
+            const SizedBox(height: 10),
+            PantryItemCard(
+              name: 'Parmesan Cheese',
+              details: '150g • Wedge',
+              status: PantryItemStatus.fresh,
+              onEdit: () {},
+            ),
+            const SizedBox(height: 12),
+            PantryItemCard(
+              name: 'Full Cream Milk',
+              details: '1L • Carton',
+              status: PantryItemStatus.low,
+              onEdit: () {},
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/features/pantry/screens/pantry_screen.dart
+++ b/frontend/lib/features/pantry/screens/pantry_screen.dart
@@ -46,7 +46,7 @@ class PantryScreen extends StatelessWidget {
         onRouteSelected: (route) => context.go(route),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {},
+        onPressed: () => context.go(AppRoutes.addIngredient),
         backgroundColor: AppColors.primary,
         foregroundColor: AppColors.textDark,
         child: const Icon(Icons.add),

--- a/frontend/lib/features/pantry/widgets/pantry_item_card.dart
+++ b/frontend/lib/features/pantry/widgets/pantry_item_card.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_colours.dart';
+import '../../../core/theme/app_typography.dart';
+
+enum PantryItemStatus {
+  fresh,
+  low,
+  expired,
+}
+
+class PantryItemCard extends StatelessWidget {
+  const PantryItemCard({
+    super.key,
+    required this.name,
+    required this.details,
+    required this.status,
+    this.imageUrl,
+    this.onEdit,
+    this.onDelete,
+  });
+
+  final String name;
+  final String details;
+  final PantryItemStatus status;
+  final String? imageUrl;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
+
+  bool get _isExpired => status == PantryItemStatus.expired;
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColor = switch (status) {
+      PantryItemStatus.fresh => AppColors.success,
+      PantryItemStatus.low => AppColors.warning,
+      PantryItemStatus.expired => AppColors.error,
+    };
+
+    final statusLabel = switch (status) {
+      PantryItemStatus.fresh => 'Fresh',
+      PantryItemStatus.low => 'Low',
+      PantryItemStatus.expired => 'Expired',
+    };
+
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: _isExpired
+            ? AppColors.error.withValues(alpha: 0.06)
+            : AppColors.textDark,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: _isExpired
+              ? AppColors.error.withValues(alpha: 0.22)
+              : AppColors.divider.withValues(alpha: 0.55),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.textLight.withValues(alpha: 0.05),
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          _IngredientImage(imageUrl: imageUrl),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    name,
+                    style: AppTextStyles.body.copyWith(
+                      color: _isExpired ? AppColors.error : AppColors.textLight,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    details,
+                    style: AppTextStyles.bodySmall.copyWith(
+                      color: _isExpired ? AppColors.error : AppColors.primary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              _StatusLabel(label: statusLabel, color: statusColor),
+              const SizedBox(height: 22),
+              IconButton(
+                onPressed: _isExpired ? onDelete : onEdit,
+                icon: Icon(
+                  _isExpired ? Icons.delete_outline : Icons.edit_outlined,
+                  size: 18,
+                  color: _isExpired ? AppColors.error : AppColors.primary,
+                ),
+                tooltip: _isExpired ? 'Delete ingredient' : 'Edit ingredient',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IngredientImage extends StatelessWidget {
+  const _IngredientImage({this.imageUrl});
+
+  final String? imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(7),
+      child: Container(
+        width: 58,
+        height: 58,
+        color: AppColors.surfaceLight,
+        child: imageUrl == null
+            ? const Icon(
+                Icons.restaurant_outlined,
+                color: AppColors.primary,
+              )
+            : Image.network(imageUrl!, fit: BoxFit.cover),
+      ),
+    );
+  }
+}
+
+class _StatusLabel extends StatelessWidget {
+  const _StatusLabel({
+    required this.label,
+    required this.color,
+  });
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        CircleAvatar(radius: 3.5, backgroundColor: color),
+        const SizedBox(width: 5),
+        Text(
+          label,
+          style: AppTextStyles.bodySmall.copyWith(color: AppColors.textMuted),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/features/pantry/widgets/pantry_summary_card.dart
+++ b/frontend/lib/features/pantry/widgets/pantry_summary_card.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_colours.dart';
+import '../../../core/theme/app_typography.dart';
+
+class PantrySummaryCard extends StatelessWidget {
+  const PantrySummaryCard({
+    super.key,
+    required this.totalItems,
+    required this.freshnessPercent,
+    required this.categoryCount,
+    required this.optimizationPercent,
+  });
+
+  final int totalItems;
+  final int freshnessPercent;
+  final int categoryCount;
+  final int optimizationPercent;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (optimizationPercent.clamp(0, 100)) / 100;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(22, 24, 22, 18),
+      decoration: BoxDecoration(
+        color: AppColors.bgLight,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: AppColors.accent),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.textLight.withValues(alpha: 0.12),
+            blurRadius: 18,
+            offset: const Offset(0, 9),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              _SummaryMetric(
+                value: '$totalItems',
+                label: 'TOTAL ITEMS',
+              ),
+              const Spacer(),
+              _SummaryMetric(
+                value: '$freshnessPercent%',
+                label: 'FRESHNESS',
+                highlight: true,
+              ),
+              const Spacer(),
+              Container(width: 1, height: 52, color: AppColors.primary),
+              const Spacer(),
+              _SummaryMetric(
+                value: '$categoryCount',
+                label: 'CATEGORIES',
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Text(
+                'Meal Optimization',
+                style: AppTextStyles.body.copyWith(
+                  color: AppColors.textLight,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '$optimizationPercent%',
+                style: AppTextStyles.body.copyWith(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(99),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 6,
+              backgroundColor: AppColors.surfaceLight,
+              valueColor: const AlwaysStoppedAnimation<Color>(
+                AppColors.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryMetric extends StatelessWidget {
+  const _SummaryMetric({
+    required this.value,
+    required this.label,
+    this.highlight = false,
+  });
+
+  final String value;
+  final String label;
+  final bool highlight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          value,
+          style: AppTextStyles.heading2.copyWith(
+            color: highlight ? AppColors.primary : AppColors.textLight,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 3),
+        Text(
+          label,
+          style: AppTextStyles.label.copyWith(
+            color: AppColors.textMuted,
+            fontSize: 9,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/features/preference/screens/preference_screen.dart
+++ b/frontend/lib/features/preference/screens/preference_screen.dart
@@ -1,13 +1,186 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/routes/app_routes.dart';
+import '../../../core/shared_widgets/Molecules/app_section_header.dart';
+import '../../../core/shared_widgets/Organisms/app_navbar.dart';
+import '../../../core/shared_widgets/atoms/app_button.dart';
+import '../../../core/shared_widgets/atoms/app_text_field.dart';
+import '../../../core/theme/app_colours.dart';
+import '../../../core/theme/app_typography.dart';
+import '../widgets/flavour_profile_card.dart';
+import '../widgets/preference_option_card.dart';
+import '../widgets/preference_tag_chip.dart';
 
 class PreferenceScreen extends StatelessWidget {
   const PreferenceScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    // Temporary mock data until preferences API is connected.
+    final selectedAllergies = ['PEANUTS', 'SHELLFISH'];
+    final availableAllergies = ['TREE NUTS', 'SOY', 'EGGS'];
+    final dislikedIngredients = ['CILANTRO', 'CAPERS', 'BLUE CHEESE'];
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Preference')),
-      body: const Center(child: Text('Preference Screen')),
+      backgroundColor: AppColors.bgLight,
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.settings_outlined),
+            tooltip: 'Settings',
+          ),
+        ],
+      ),
+      bottomNavigationBar: AppNavbar(
+        currentRoute: AppRoutes.preference,
+        onRouteSelected: (route) => context.go(route),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 18, 20, 28),
+          children: [
+            Text(
+              'PERSONALIZED CURATION',
+              style: AppTextStyles.label.copyWith(
+                color: AppColors.primary,
+                letterSpacing: 1.1,
+              ),
+            ),
+            const SizedBox(height: 14),
+            Text(
+              'Bespoke Culinary\nProfile',
+              style: AppTextStyles.heading1.copyWith(
+                color: AppColors.primary,
+                height: 1.05,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Fine-tune your Mealchemy journey by defining the boundaries of your palate. Our curators use these directives to tailor every recommendation to your specific lifestyle.',
+              style: AppTextStyles.body.copyWith(
+                color: AppColors.textMuted,
+                height: 1.55,
+              ),
+            ),
+            const SizedBox(height: 32),
+
+            // Dietary selection cards.
+            const AppSectionHeader(title: 'Dietary Directives'),
+            const SizedBox(height: 14),
+            const PreferenceOptionCard(
+              title: 'PLANT-BASED / VEGAN',
+              subtitle: 'Exclusively botanical-led cuisine.',
+            ),
+            const SizedBox(height: 10),
+            const PreferenceOptionCard(
+              title: 'CELIAC FRIENDLY / GLUTEN-FREE',
+              subtitle: 'Rigorous gluten-free adherence.',
+              selected: true,
+            ),
+            const SizedBox(height: 10),
+            const PreferenceOptionCard(
+              title: 'DAIRY FREE',
+              subtitle: 'Lactose and casein-free alternatives.',
+            ),
+            const SizedBox(height: 10),
+            const PreferenceOptionCard(
+              title: 'CARB CONSCIOUS / KETO',
+              subtitle: 'High protein and healthy fats focus.',
+            ),
+            const SizedBox(height: 32),
+
+            // Allergy and dislike tags.
+            const AppSectionHeader(title: 'Critical Allergies'),
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                ...selectedAllergies.map(
+                  (allergy) => PreferenceTagChip(
+                    label: allergy,
+                    selected: true,
+                    onRemove: () {},
+                  ),
+                ),
+                ...availableAllergies.map(
+                  (allergy) => PreferenceTagChip(
+                    label: allergy,
+                    onTap: () {},
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 32),
+            const AppSectionHeader(title: 'Aversions & Dislikes'),
+            const SizedBox(height: 14),
+            AppTextField(
+              hint: 'Add an ingredient...',
+              suffixIcon: IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.add),
+                tooltip: 'Add ingredient',
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: dislikedIngredients
+                  .map(
+                    (ingredient) => PreferenceTagChip(
+                      label: ingredient,
+                      selected: true,
+                      onRemove: () {},
+                    ),
+                  )
+                  .toList(),
+            ),
+            const SizedBox(height: 28),
+
+            //cuisine preference cards
+            const AppSectionHeader(title: 'Flavour Profiles'),
+            const SizedBox(height: 16),
+            const FlavourProfileCard(
+              label: 'Mediterranean',
+              description: 'Bright herbs, olive oil, citrus, grains, and fresh vegetables.',
+              icon: Icons.local_florist_outlined,
+              selected: true,
+            ),
+            const SizedBox(height: 12),
+            const FlavourProfileCard(
+              label: 'Asian Fusion',
+              description: 'Soy, ginger, chilli, sesame, rice bowls, noodles, and umami-rich sauces.',
+              icon: Icons.ramen_dining_outlined,
+            ),
+            const SizedBox(height: 12),
+            const FlavourProfileCard(
+              label: 'Comfort Classics',
+              description: 'Warm, familiar meals with hearty textures and simple pantry staples.',
+              icon: Icons.soup_kitchen_outlined,
+            ),
+            const SizedBox(height: 12),
+            const FlavourProfileCard(
+              label: 'Fresh & Light',
+              description: 'Lean proteins, crisp produce, lighter sauces, and balanced portions.',
+              icon: Icons.eco_outlined,
+            ),
+            const SizedBox(height: 40),
+            AppButton(
+              label: 'Update Profile',
+              onPressed: () {},
+            ),
+            const SizedBox(height: 14),
+            AppButton(
+              label: 'Reset All Directives',
+              variant: AppButtonVariant.outline,
+              onPressed: () {},
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/features/preference/widgets/flavour_profile_card.dart
+++ b/frontend/lib/features/preference/widgets/flavour_profile_card.dart
@@ -7,62 +7,87 @@ class FlavourProfileCard extends StatelessWidget {
   const FlavourProfileCard({
     super.key,
     required this.label,
-    required this.imageUrl,
+    required this.description,
+    required this.icon,
     this.selected = false,
     this.onTap,
   });
 
   final String label;
-  final String imageUrl;
+  final String description;
+  final IconData icon;
   final bool selected;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
+    final backgroundColor =
+        selected ? AppColors.primary : AppColors.surfaceLight;
+    final foregroundColor =
+        selected ? AppColors.textDark : AppColors.textLight;
+    final mutedColor = selected
+        ? AppColors.textDark.withValues(alpha: 0.78)
+        : AppColors.textMuted;
+
     return Material(
-      color: AppColors.surfaceLight,
+      color: backgroundColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(
+          color: selected ? AppColors.primary : AppColors.divider,
+        ),
+      ),
       child: InkWell(
         onTap: onTap,
-        child: AspectRatio(
-          aspectRatio: 1.55,
-          child: Stack(
-            fit: StackFit.expand,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
             children: [
-              Image.network(imageUrl, fit: BoxFit.cover),
-              if (selected)
-                Container(color: AppColors.primary.withValues(alpha: 0.35)),
-              Positioned(
-                left: 18,
-                bottom: 18,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  color: AppColors.accent,
-                  child: Text(
-                    label.toUpperCase(),
-                    style: AppTextStyles.label.copyWith(
-                      color: AppColors.textLight,
-                      fontSize: 9,
-                    ),
-                  ),
+              Container(
+                width: 46,
+                height: 46,
+                decoration: BoxDecoration(
+                  color: selected
+                      ? AppColors.textDark.withValues(alpha: 0.12)
+                      : AppColors.primary.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  icon,
+                  color: selected ? AppColors.textDark : AppColors.primary,
+                  size: 24,
                 ),
               ),
-              if (selected)
-                const Positioned(
-                  right: 14,
-                  bottom: 14,
-                  child: CircleAvatar(
-                    radius: 13,
-                    backgroundColor: AppColors.textDark,
-                    child: Icon(
-                      Icons.check,
-                      size: 17,
-                      color: AppColors.primary,
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label.toUpperCase(),
+                      style: AppTextStyles.label.copyWith(
+                        color: foregroundColor,
+                        letterSpacing: 0.7,
+                      ),
                     ),
-                  ),
+                    const SizedBox(height: 6),
+                    Text(
+                      description,
+                      style: AppTextStyles.bodySmall.copyWith(
+                        color: mutedColor,
+                        height: 1.35,
+                      ),
+                    ),
+                  ],
                 ),
+              ),
+              const SizedBox(width: 10),
+              Icon(
+                selected ? Icons.check_circle : Icons.add_circle_outline,
+                color: selected ? AppColors.textDark : AppColors.primary,
+                size: 20,
+              ),
             ],
           ),
         ),

--- a/frontend/lib/features/preference/widgets/flavour_profile_card.dart
+++ b/frontend/lib/features/preference/widgets/flavour_profile_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../core/theme/app_colours.dart';
 import '../../../core/theme/app_typography.dart';
 
+//select cuisine/flavour cards
 class FlavourProfileCard extends StatelessWidget {
   const FlavourProfileCard({
     super.key,

--- a/frontend/lib/features/preference/widgets/flavour_profile_card.dart
+++ b/frontend/lib/features/preference/widgets/flavour_profile_card.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_colours.dart';
+import '../../../core/theme/app_typography.dart';
+
+class FlavourProfileCard extends StatelessWidget {
+  const FlavourProfileCard({
+    super.key,
+    required this.label,
+    required this.imageUrl,
+    this.selected = false,
+    this.onTap,
+  });
+
+  final String label;
+  final String imageUrl;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surfaceLight,
+      child: InkWell(
+        onTap: onTap,
+        child: AspectRatio(
+          aspectRatio: 1.55,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Image.network(imageUrl, fit: BoxFit.cover),
+              if (selected)
+                Container(color: AppColors.primary.withValues(alpha: 0.35)),
+              Positioned(
+                left: 18,
+                bottom: 18,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  color: AppColors.accent,
+                  child: Text(
+                    label.toUpperCase(),
+                    style: AppTextStyles.label.copyWith(
+                      color: AppColors.textLight,
+                      fontSize: 9,
+                    ),
+                  ),
+                ),
+              ),
+              if (selected)
+                const Positioned(
+                  right: 14,
+                  bottom: 14,
+                  child: CircleAvatar(
+                    radius: 13,
+                    backgroundColor: AppColors.textDark,
+                    child: Icon(
+                      Icons.check,
+                      size: 17,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/preference/widgets/preference_option_card.dart
+++ b/frontend/lib/features/preference/widgets/preference_option_card.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_colours.dart';
+import '../../../core/theme/app_typography.dart';
+
+class PreferenceOptionCard extends StatelessWidget {
+  const PreferenceOptionCard({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    this.selected = false,
+    this.onTap,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = selected ? AppColors.primary : AppColors.bgLight;
+    final foregroundColor = selected ? AppColors.textDark : AppColors.textLight;
+    final subtitleColor =
+        selected ? AppColors.textDark.withValues(alpha: 0.82) : AppColors.textMuted;
+    final borderColor = selected ? AppColors.primary : AppColors.divider;
+
+    return Material(
+      color: backgroundColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(2),
+        side: BorderSide(color: borderColor),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(18, 16, 14, 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: AppTextStyles.label.copyWith(
+                        color: foregroundColor,
+                        letterSpacing: 0.8,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      subtitle,
+                      style: AppTextStyles.bodySmall.copyWith(
+                        color: subtitleColor,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (selected)
+                const Icon(
+                  Icons.check_circle,
+                  color: AppColors.textDark,
+                  size: 18,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/preference/widgets/preference_tag_chip.dart
+++ b/frontend/lib/features/preference/widgets/preference_tag_chip.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/shared_widgets/atoms/app_chip.dart';
+
+class PreferenceTagChip extends StatelessWidget {
+  const PreferenceTagChip({
+    super.key,
+    required this.label,
+    this.selected = false,
+    this.onTap,
+    this.onRemove,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback? onTap;
+  final VoidCallback? onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppChip(
+      label: label,
+      selected: selected,
+      onTap: onTap,
+      onRemove: onRemove,
+    );
+  }
+}

--- a/frontend/test/core/shared_widgets/atoms/app_chip_test.dart
+++ b/frontend/test/core/shared_widgets/atoms/app_chip_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/core/shared_widgets/atoms/app_chip.dart';
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('AppChip renders label and remove icon', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AppChip(
+            label: 'PEANUTS',
+            selected: true,
+            onRemove: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('PEANUTS'), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsOneWidget);
+  });
+
+  testWidgets('AppChip hides remove icon when onRemove is null', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AppChip(
+            label: 'SOY',
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('SOY'), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsNothing);
+  });
+}

--- a/frontend/test/features/pantry/screens/add_ingredient_screen_test.dart
+++ b/frontend/test/features/pantry/screens/add_ingredient_screen_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/features/pantry/screens/add_ingredient_screen.dart';
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('AddIngredientScreen renders manual ingredient form', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AddIngredientScreen(),
+      ),
+    );
+
+    expect(find.text('Add Ingredient\nManually'), findsOneWidget);
+    expect(find.text('Ingredient Details'), findsOneWidget);
+    expect(find.text('Ingredient name'), findsOneWidget);
+    expect(find.text('Quantity'), findsWidgets);
+  });
+}

--- a/frontend/test/features/pantry/screens/pantry_test.dart
+++ b/frontend/test/features/pantry/screens/pantry_test.dart
@@ -1,12 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:mealchemy/features/pantry/screens/pantry_screen.dart';
 
 void main() {
-  testWidgets('PantryScreen renders correctly', (tester) async {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('PantryScreen renders pantry overview', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: PantryScreen()),
+      const MaterialApp(
+        home: PantryScreen(),
+      ),
     );
-    expect(find.text('Pantry'), findsOneWidget);
+
+    expect(find.text('Pantry'), findsWidgets);
+    expect(find.text('Meal Optimization'), findsOneWidget);
+    expect(find.text('Proteins'), findsOneWidget);
+    expect(find.text('Chicken Breast'), findsOneWidget);
   });
 }

--- a/frontend/test/features/pantry/widgets/pantry_item_card_test.dart
+++ b/frontend/test/features/pantry/widgets/pantry_item_card_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/features/pantry/widgets/pantry_item_card.dart';
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('PantryItemCard renders ingredient details and fresh status', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PantryItemCard(
+            name: 'Chicken Breast',
+            details: '800g • Refrigerated',
+            status: PantryItemStatus.fresh,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Chicken Breast'), findsOneWidget);
+    expect(find.text('800g • Refrigerated'), findsOneWidget);
+    expect(find.text('Fresh'), findsOneWidget);
+    expect(find.byIcon(Icons.restaurant_outlined), findsOneWidget);
+  });
+
+  testWidgets('PantryItemCard shows delete action for expired items', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PantryItemCard(
+            name: 'Baby Spinach',
+            details: '200g • Expired 2 days ago',
+            status: PantryItemStatus.expired,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Baby Spinach'), findsOneWidget);
+    expect(find.text('Expired'), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+  });
+}

--- a/frontend/test/features/pantry/widgets/pantry_summary_card_test.dart
+++ b/frontend/test/features/pantry/widgets/pantry_summary_card_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/features/pantry/widgets/pantry_summary_card.dart';
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('PantrySummaryCard renders pantry metrics', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PantrySummaryCard(
+            totalItems: 42,
+            freshnessPercent: 84,
+            categoryCount: 6,
+            optimizationPercent: 72,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('42'), findsOneWidget);
+    expect(find.text('84%'), findsOneWidget);
+    expect(find.text('6'), findsOneWidget);
+    expect(find.text('72%'), findsOneWidget);
+    expect(find.text('Meal Optimization'), findsOneWidget);
+  });
+}

--- a/frontend/test/features/preference/screens/preference_test.dart
+++ b/frontend/test/features/preference/screens/preference_test.dart
@@ -1,12 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:mealchemy/features/preference/screens/preference_screen.dart';
 
 void main() {
-  testWidgets('PreferenceScreen renders correctly', (tester) async {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('PreferenceScreen renders preference overview', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: PreferenceScreen()),
+      const MaterialApp(
+        home: PreferenceScreen(),
+      ),
     );
-    expect(find.text('Preference'), findsOneWidget);
+
+    expect(find.text('Bespoke Culinary\nProfile'), findsOneWidget);
+    expect(find.text('Dietary Directives'), findsOneWidget);
+    expect(find.text('PLANT-BASED / VEGAN'), findsOneWidget);
+    expect(find.text('CELIAC FRIENDLY / GLUTEN-FREE'), findsOneWidget);
   });
 }

--- a/frontend/test/features/preference/widgets/flavour_profile_card_test.dart
+++ b/frontend/test/features/preference/widgets/flavour_profile_card_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/features/preference/widgets/flavour_profile_card.dart';
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('FlavourProfileCard renders selected profile details', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FlavourProfileCard(
+            label: 'Mediterranean',
+            description: 'Bright herbs and fresh vegetables.',
+            icon: Icons.local_florist_outlined,
+            selected: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('MEDITERRANEAN'), findsOneWidget);
+    expect(find.text('Bright herbs and fresh vegetables.'), findsOneWidget);
+    expect(find.byIcon(Icons.local_florist_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('FlavourProfileCard calls onTap when tapped', (tester) async {
+    var tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FlavourProfileCard(
+            label: 'Fresh & Light',
+            description: 'Lean proteins and crisp produce.',
+            icon: Icons.eco_outlined,
+            onTap: () => tapped = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('FRESH & LIGHT'));
+    expect(tapped, isTrue);
+  });
+}

--- a/frontend/test/features/preference/widgets/preference_option_card_test.dart
+++ b/frontend/test/features/preference/widgets/preference_option_card_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/features/preference/widgets/preference_option_card.dart';
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('PreferenceOptionCard renders selected option state', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PreferenceOptionCard(
+            title: 'CELIAC FRIENDLY / GLUTEN-FREE',
+            subtitle: 'Rigorous gluten-free adherence.',
+            selected: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('CELIAC FRIENDLY / GLUTEN-FREE'), findsOneWidget);
+    expect(find.text('Rigorous gluten-free adherence.'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('PreferenceOptionCard calls onTap when tapped', (tester) async {
+    var tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PreferenceOptionCard(
+            title: 'DAIRY FREE',
+            subtitle: 'Lactose and casein-free alternatives.',
+            onTap: () => tapped = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('DAIRY FREE'));
+    expect(tapped, isTrue);
+  });
+}


### PR DESCRIPTION
What changed:

Shared Components:
AppChip - selectable/removable chip component for allergies, dislikes, and filters
AppTextField - reusable styled text input for forms and search-based fields
AppSearchBar - shared search input built on AppTextField
AppSectionHeader - reusable section heading with optional trailing label
AppFilterBar - horizontal filter chips for pantry/category filtering
AppNavbar - shared bottom navigation for main feature screens

Preference Profile:
Added Preference Profile screen layout using mock preference data
Added dietary directive cards, allergy/dislike chips, and flavour profile dashboard cards
Added PreferenceOptionCard, PreferenceTagChip, and FlavourProfileCard widgets

Pantry :
Added Pantry screen layout using mock pantry data
Added pantry summary metrics, category sections, pantry item cards, and navigation to manual entry
Added PantryItemCard and PantrySummaryCard widgets

Manual Ingredient Entry:
Added Add Ingredient screen and route
Added manual form layout for ingredient name, category, quantity, unit, price paid, and stock status
Connected Pantry floating action button to the Add Ingredient route

Routing:
Added add ingredient route constant and router entry

Tests:
Widget tests for AppChip, Preference Profile screen, Pantry screen, Add Ingredient screen, PreferenceOptionCard, FlavourProfileCard, PantryItemCard, and PantrySummaryCard

Notes :
Screens currently use temporary mock data only
Riverpod state management and backend API integration will be handled in a follow-up PR

Mock Data Pattern:
The current screens use temporary mock values directly in the UI so the layout could be built and reviewed quickly.
Next, dynamic content should be moved into mock models/providers instead of being hardcoded in the widgets. For example, instead of rendering a fixed value like `'Chicken Breast'`, the screen should render something like `ingredient.name` from a mock pantry ingredient model.

This will make the transition to backend/API integration easier because the screens will already be structured around data objects rather than fixed display values.

Follow-up work:
- Create mock models for pantry ingredients and user preferences
- Move temporary screen data into mock provider files
- Replace mock providers with real Riverpod/API providers once backend endpoints are ready
- Connect Preference Profile to the user preferences API
- Connect Pantry and Add Ingredient screens to the pantry API