### PR TITLE
setting own tomcat version to retarget all Tomcat aritifact managed b…

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<java.version>21</java.version>
 		<postgresql.version>42.7.11</postgresql.version>
+		<tomcat.version>10.1.55</tomcat.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Pinned Tomcat version 10.1.55 in properties tag in pom.xml.
This retargets all Tomcat artifacts managed by SpringBoot to the patched version.

Trivvy check picked up issue, should fix failing check