### PR TITLE
Feature/mockdata/sofia finlayson

### DIFF
--- a/frontend/lib/features/pantry/models/pantry_ingredient.dart
+++ b/frontend/lib/features/pantry/models/pantry_ingredient.dart
@@ -1,0 +1,16 @@
+import '../widgets/pantry_item_card.dart';
+
+//data for one pantry ingredient row
+class PantryIngredient {
+  const PantryIngredient({
+    required this.name,
+    required this.details,
+    required this.category,
+    required this.status,
+  });
+
+  final String name;
+  final String details;
+  final String category;
+  final PantryItemStatus status;
+}

--- a/frontend/lib/features/pantry/models/pantry_summary.dart
+++ b/frontend/lib/features/pantry/models/pantry_summary.dart
@@ -1,0 +1,25 @@
+//summaries at the top of pantry page (freshness, categories, etc)
+class PantrySummary {
+  const PantrySummary({
+    required this.totalItems,
+    required this.freshnessPercent,
+    required this.categoryCount,
+    required this.optimizationPercent,
+  });
+
+  final int totalItems;
+  final int freshnessPercent;
+  final int categoryCount;
+  final int optimizationPercent;
+}
+
+//filtering
+class PantryFilter {
+  const PantryFilter({
+    required this.label,
+    required this.count,
+  });
+
+  final String label;
+  final int count;
+}

--- a/frontend/lib/features/pantry/providers/pantry_provider.dart
+++ b/frontend/lib/features/pantry/providers/pantry_provider.dart
@@ -1,1 +1,42 @@
 // Holds the user's pantry item list.
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/constants/app_config.dart';
+import '../models/pantry_ingredient.dart';
+import '../models/pantry_summary.dart';
+import '../repositories/api_pantry_repository.dart';
+import '../repositories/mock_pantry_repository.dart';
+import '../repositories/pantry_repository.dart';
+
+//selects mock/API repo
+final pantryRepositoryProvider = Provider<PantryRepository>((ref) {
+  if (AppConfig.useMockData) {
+    return MockPantryRepository();
+  }
+
+  return ApiPantryRepository();
+});
+
+//pantry summaries
+final pantrySummaryProvider = FutureProvider<PantrySummary>((ref) {
+  final repository = ref.watch(pantryRepositoryProvider);
+  return repository.getPantrySummary();
+});
+
+//pantry filtering
+final pantryFiltersProvider = FutureProvider<List<PantryFilter>>((ref) {
+  final repository = ref.watch(pantryRepositoryProvider);
+  return repository.getPantryFilters();
+});
+
+//pantry ingredients
+final pantryIngredientsProvider = FutureProvider<List<PantryIngredient>>((ref) {
+  final repository = ref.watch(pantryRepositoryProvider);
+  return repository.getPantryIngredients();
+});
+
+//ingredient categories (user adds)
+final ingredientCategoriesProvider = FutureProvider<List<String>>((ref) {
+  final repository = ref.watch(pantryRepositoryProvider);
+  return repository.getIngredientCategories();
+});

--- a/frontend/lib/features/pantry/repositories/api_pantry_repository.dart
+++ b/frontend/lib/features/pantry/repositories/api_pantry_repository.dart
@@ -1,0 +1,34 @@
+import '../models/pantry_ingredient.dart';
+import '../models/pantry_summary.dart';
+import 'pantry_repository.dart';
+
+//backend pantry data (future)
+class ApiPantryRepository implements PantryRepository {
+  @override
+  Future<PantrySummary> getPantrySummary() {
+    throw UnimplementedError(
+      'Pantry API integration has not been implemented yet.',
+    );
+  }
+
+  @override
+  Future<List<PantryFilter>> getPantryFilters() {
+    throw UnimplementedError(
+      'Pantry API integration has not been implemented yet.',
+    );
+  }
+
+  @override
+  Future<List<PantryIngredient>> getPantryIngredients() {
+    throw UnimplementedError(
+      'Pantry API integration has not been implemented yet.',
+    );
+  }
+
+  @override
+  Future<List<String>> getIngredientCategories() {
+    throw UnimplementedError(
+      'Pantry API integration has not been implemented yet.',
+    );
+  }
+}

--- a/frontend/lib/features/pantry/repositories/mock_pantry_repository.dart
+++ b/frontend/lib/features/pantry/repositories/mock_pantry_repository.dart
@@ -1,0 +1,88 @@
+import '../models/pantry_ingredient.dart';
+import '../models/pantry_summary.dart';
+import '../widgets/pantry_item_card.dart';
+import 'pantry_repository.dart';
+
+//mock data (while API not connected)
+class MockPantryRepository implements PantryRepository {
+  @override
+  Future<PantrySummary> getPantrySummary() async {
+    return const PantrySummary(
+      totalItems: 42,
+      freshnessPercent: 84,
+      categoryCount: 6,
+      optimizationPercent: 72,
+    );
+  }
+
+  @override
+  Future<List<PantryFilter>> getPantryFilters() async {
+    return const [
+      PantryFilter(label: 'All', count: 42),
+      PantryFilter(label: 'Proteins', count: 2),
+      PantryFilter(label: 'Vegetables', count: 2),
+      PantryFilter(label: 'Dairy', count: 2),
+    ];
+  }
+
+  @override
+  Future<List<PantryIngredient>> getPantryIngredients() async {
+    return const [
+      PantryIngredient(
+        name: 'Chicken Breast',
+        details: '800g • Refrigerated',
+        category: 'Proteins',
+        status: PantryItemStatus.fresh,
+      ),
+      PantryIngredient(
+        name: 'Salmon Fillet',
+        details: '150g • Use by tomorrow',
+        category: 'Proteins',
+        status: PantryItemStatus.low,
+      ),
+      PantryIngredient(
+        name: 'Cherry Tomatoes',
+        details: '~10 pcs • Pantry',
+        category: 'Vegetables',
+        status: PantryItemStatus.low,
+      ),
+      PantryIngredient(
+        name: 'Baby Spinach',
+        details: '200g • Expired 2 days ago',
+        category: 'Vegetables',
+        status: PantryItemStatus.expired,
+      ),
+      PantryIngredient(
+        name: 'Parmesan Cheese',
+        details: '150g • Wedge',
+        category: 'Dairy',
+        status: PantryItemStatus.fresh,
+      ),
+      PantryIngredient(
+        name: 'Full Cream Milk',
+        details: '1L • Carton',
+        category: 'Dairy',
+        status: PantryItemStatus.low,
+      ),
+    ];
+  }
+
+  @override
+  Future<List<String>> getIngredientCategories() async {
+    return const [
+      'produce',
+      'dairy',
+      'meat',
+      'poultry',
+      'seafood',
+      'grains',
+      'legumes',
+      'spices',
+      'condiments',
+      'beverages',
+      'frozen',
+      'snacks',
+      'other',
+    ];
+  }
+}

--- a/frontend/lib/features/pantry/repositories/pantry_repository.dart
+++ b/frontend/lib/features/pantry/repositories/pantry_repository.dart
@@ -1,0 +1,13 @@
+import '../models/pantry_ingredient.dart';
+import '../models/pantry_summary.dart';
+
+//uses mock/API data
+abstract class PantryRepository {
+  Future<PantrySummary> getPantrySummary();
+
+  Future<List<PantryFilter>> getPantryFilters();
+
+  Future<List<PantryIngredient>> getPantryIngredients();
+
+  Future<List<String>> getIngredientCategories();
+}

--- a/frontend/lib/features/pantry/screens/add_ingredient_screen.dart
+++ b/frontend/lib/features/pantry/screens/add_ingredient_screen.dart
@@ -1,33 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/shared_widgets/Molecules/app_section_header.dart';
 import '../../../core/shared_widgets/atoms/app_button.dart';
 import '../../../core/shared_widgets/atoms/app_text_field.dart';
-import '../../../core/shared_widgets/Molecules/app_section_header.dart';
 import '../../../core/theme/app_colours.dart';
 import '../../../core/theme/app_typography.dart';
+import '../providers/pantry_provider.dart';
 
-class AddIngredientScreen extends StatelessWidget {
+//stateless state to consumer widget
+class AddIngredientScreen extends ConsumerWidget {
   const AddIngredientScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    //temporary form values until API connected
-    final categories = [
-      'produce',
-      'dairy',
-      'meat',
-      'poultry',
-      'seafood',
-      'grains',
-      'legumes',
-      'spices',
-      'condiments',
-      'beverages',
-      'frozen',
-      'snacks',
-      'other',
-    ];
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categoriesState = ref.watch(ingredientCategoriesProvider);
 
     return Scaffold(
       backgroundColor: AppColors.bgLight,
@@ -40,94 +28,114 @@ class AddIngredientScreen extends StatelessWidget {
         title: const Text('Add Ingredient'),
       ),
       body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 18, 20, 28),
+        child: categoriesState.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => _AddIngredientError(message: '$error'),
+          data: (categories) => _AddIngredientContent(categories: categories),
+        ),
+      ),
+    );
+  }
+}
+
+class _AddIngredientContent extends StatelessWidget {
+  const _AddIngredientContent({required this.categories});
+
+  final List<String> categories;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 18, 20, 28),
+      children: [
+        Text(
+          'PANTRY ENTRY',
+          style: AppTextStyles.label.copyWith(
+            color: AppColors.primary,
+            letterSpacing: 1.1,
+          ),
+        ),
+        const SizedBox(height: 14),
+        Text(
+          'Add Ingredient\nManually',
+          style: AppTextStyles.heading1.copyWith(
+            color: AppColors.primary,
+            height: 1.05,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Capture the ingredient details you have on hand. This will later help Mealchemy match recipes to your pantry.',
+          style: AppTextStyles.body.copyWith(
+            color: AppColors.textMuted,
+            height: 1.55,
+          ),
+        ),
+        const SizedBox(height: 32),
+
+        //ingredients
+        const AppSectionHeader(title: 'Ingredient Details'),
+        const SizedBox(height: 14),
+        AppTextField(
+          label: 'Ingredient name',
+          hint: 'e.g. Chicken breast',
+          onChanged: (_) {},
+        ),
+        const SizedBox(height: 14),
+        _CategorySelector(categories: categories),
+        const SizedBox(height: 28),
+
+        //amount + units
+        const AppSectionHeader(title: 'Quantity'),
+        const SizedBox(height: 14),
+        Row(
           children: [
-            Text(
-              'PANTRY ENTRY',
-              style: AppTextStyles.label.copyWith(
-                color: AppColors.primary,
-                letterSpacing: 1.1,
+            Expanded(
+              child: AppTextField(
+                label: 'Quantity',
+                hint: 'e.g. 800',
+                keyboardType: TextInputType.number,
+                onChanged: (_) {},
               ),
             ),
-            const SizedBox(height: 14),
-            Text(
-              'Add Ingredient\nManually',
-              style: AppTextStyles.heading1.copyWith(
-                color: AppColors.primary,
-                height: 1.05,
+            const SizedBox(width: 12),
+            Expanded(
+              child: AppTextField(
+                label: 'Unit',
+                hint: 'g, ml, cups',
+                onChanged: (_) {},
               ),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              'Capture the ingredient details you have on hand. This will later help Mealchemy match recipes to your pantry.',
-              style: AppTextStyles.body.copyWith(
-                color: AppColors.textMuted,
-                height: 1.55,
-              ),
-            ),
-            const SizedBox(height: 32),
-            //ingredients
-            const AppSectionHeader(title: 'Ingredient Details'),
-            const SizedBox(height: 14),
-            AppTextField(
-              label: 'Ingredient name',
-              hint: 'e.g. Chicken breast',
-              onChanged: (_) {},
-            ),
-            const SizedBox(height: 14),
-            _CategorySelector(categories: categories),
-            const SizedBox(height: 28),
-            const AppSectionHeader(title: 'Quantity'),
-            const SizedBox(height: 14),
-            Row(
-              children: [
-                Expanded(
-                  child: AppTextField(
-                    label: 'Quantity',
-                    hint: 'e.g. 800',
-                    keyboardType: TextInputType.number,
-                    onChanged: (_) {},
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: AppTextField(
-                    label: 'Unit',
-                    hint: 'g, ml, cups',
-                    onChanged: (_) {},
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 28),
-            const AppSectionHeader(title: 'Purchase Info'),
-            const SizedBox(height: 14),
-            AppTextField(
-              label: 'Price paid',
-              hint: 'e.g. 89.99',
-              keyboardType: TextInputType.number,
-              prefixIcon: Icons.payments_outlined,
-              onChanged: (_) {},
-            ),
-            const SizedBox(height: 28),
-            _StockToggle(
-              value: false,
-              onChanged: (_) {},
-            ),
-            const SizedBox(height: 36),
-            AppButton(
-              label: 'Save Ingredient',
-              onPressed: () {},
-            ),
-            const SizedBox(height: 14),
-            AppButton(
-              label: 'Cancel',
-              onPressed: () => context.pop(),
             ),
           ],
         ),
-      ),
+        const SizedBox(height: 28),
+
+        //purchase details
+        const AppSectionHeader(title: 'Purchase Info'),
+        const SizedBox(height: 14),
+        AppTextField(
+          label: 'Price paid',
+          hint: 'e.g. 89.99',
+          keyboardType: TextInputType.number,
+          prefixIcon: Icons.payments_outlined,
+          onChanged: (_) {},
+        ),
+        const SizedBox(height: 28),
+        _StockToggle(
+          value: false,
+          onChanged: (_) {},
+        ),
+        const SizedBox(height: 36),
+        AppButton(
+          label: 'Save Ingredient',
+          onPressed: () {},
+        ),
+        const SizedBox(height: 14),
+        AppButton(
+          label: 'Cancel',
+          onPressed: () => context.pop(),
+        ),
+      ],
     );
   }
 }
@@ -209,6 +217,22 @@ class _StockToggle extends StatelessWidget {
         style: AppTextStyles.bodySmall.copyWith(
           color: AppColors.textMuted,
         ),
+      ),
+    );
+  }
+}
+
+class _AddIngredientError extends StatelessWidget {
+  const _AddIngredientError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'Unable to load ingredient categories.',
+        style: AppTextStyles.body.copyWith(color: AppColors.error),
       ),
     );
   }

--- a/frontend/lib/features/pantry/screens/pantry_screen.dart
+++ b/frontend/lib/features/pantry/screens/pantry_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/routes/app_routes.dart';
@@ -8,21 +9,21 @@ import '../../../core/shared_widgets/Organisms/app_filter_bar.dart';
 import '../../../core/shared_widgets/Organisms/app_navbar.dart';
 import '../../../core/theme/app_colours.dart';
 import '../../../core/theme/app_typography.dart';
+import '../models/pantry_ingredient.dart';
+import '../models/pantry_summary.dart';
+import '../providers/pantry_provider.dart';
 import '../widgets/pantry_item_card.dart';
 import '../widgets/pantry_summary_card.dart';
 
-class PantryScreen extends StatelessWidget {
+//change from stateless widget to consumer widget
+class PantryScreen extends ConsumerWidget {
   const PantryScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    //temp mock data until pantry API connected
-    final filterOptions = [
-      const AppFilterOption(label: 'All', count: 42),
-      const AppFilterOption(label: 'Proteins', count: 2),
-      const AppFilterOption(label: 'Vegetables', count: 2),
-      const AppFilterOption(label: 'Dairy', count: 2),
-    ];
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summaryState = ref.watch(pantrySummaryProvider);
+    final filtersState = ref.watch(pantryFiltersProvider);
+    final ingredientsState = ref.watch(pantryIngredientsProvider);
 
     return Scaffold(
       backgroundColor: AppColors.bgLight,
@@ -52,102 +53,138 @@ class PantryScreen extends StatelessWidget {
         child: const Icon(Icons.add),
       ),
       body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 10, 20, 28),
-          children: [
-            AppSearchBar(
-              hint: 'Search pantry...',
-              onChanged: (_) {},
-              onClear: () {},
-            ),
-            const SizedBox(height: 18),
-            Text(
-              'Pantry',
-              style: AppTextStyles.heading1.copyWith(
-                color: AppColors.primary,
+        child: summaryState.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => _PantryError(message: '$error'),
+          data: (summary) => filtersState.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, stackTrace) => _PantryError(message: '$error'),
+            data: (filters) => ingredientsState.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, stackTrace) => _PantryError(message: '$error'),
+              data: (ingredients) => _PantryContent(
+                summary: summary,
+                filters: filters,
+                ingredients: ingredients,
               ),
             ),
-            const SizedBox(height: 16),
-            AppFilterBar(
-              options: filterOptions,
-              selectedIndex: 0,
-              onSelected: (_) {},
-            ),
-            const SizedBox(height: 22),
-            const PantrySummaryCard(
-              totalItems: 42,
-              freshnessPercent: 84,
-              categoryCount: 6,
-              optimizationPercent: 72,
-            ),
-            const SizedBox(height: 26),
-            const AppSectionHeader(
-              title: 'Items',
-              trailing: '42 ITEMS',
-              showAccentLine: false,
-            ),
-            const SizedBox(height: 18),
-            const AppSectionHeader(
-              title: 'Proteins',
-              trailing: '2 ITEMS',
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PantryContent extends StatelessWidget {
+  const _PantryContent({
+    required this.summary,
+    required this.filters,
+    required this.ingredients,
+  });
+
+  final PantrySummary summary;
+  final List<PantryFilter> filters;
+  final List<PantryIngredient> ingredients;
+
+  @override
+  Widget build(BuildContext context) {
+    final groupedIngredients = _groupIngredientsByCategory(ingredients);
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 10, 20, 28),
+      children: [
+        AppSearchBar(
+          hint: 'Search pantry...',
+          onChanged: (_) {},
+          onClear: () {},
+        ),
+        const SizedBox(height: 18),
+        Text(
+          'Pantry',
+          style: AppTextStyles.heading1.copyWith(
+            color: AppColors.primary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        AppFilterBar(
+          options: filters
+              .map(
+                (filter) => AppFilterOption(
+                  label: filter.label,
+                  count: filter.count,
+                ),
+              )
+              .toList(),
+          selectedIndex: 0,
+          onSelected: (_) {},
+        ),
+        const SizedBox(height: 22),
+        PantrySummaryCard(
+          totalItems: summary.totalItems,
+          freshnessPercent: summary.freshnessPercent,
+          categoryCount: summary.categoryCount,
+          optimizationPercent: summary.optimizationPercent,
+        ),
+        const SizedBox(height: 26),
+        AppSectionHeader(
+          title: 'Items',
+          trailing: '${summary.totalItems} ITEMS',
+          showAccentLine: false,
+        ),
+        const SizedBox(height: 18),
+        ...groupedIngredients.entries.expand(
+          (entry) => [
+            AppSectionHeader(
+              title: entry.key,
+              trailing: '${entry.value.length} ITEMS',
               showAccentLine: false,
             ),
             const SizedBox(height: 10),
-            PantryItemCard(
-              name: 'Chicken Breast',
-              details: '800g • Refrigerated',
-              status: PantryItemStatus.fresh,
-              onEdit: () {},
-            ),
-            const SizedBox(height: 12),
-            PantryItemCard(
-              name: 'Salmon Fillet',
-              details: '150g • Use by tomorrow',
-              status: PantryItemStatus.low,
-              onEdit: () {},
-            ),
-            const SizedBox(height: 22),
-            const AppSectionHeader(
-              title: 'Vegetables',
-              trailing: '2 ITEMS',
-              showAccentLine: false,
+            ...entry.value.map(
+              (ingredient) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: PantryItemCard(
+                  name: ingredient.name,
+                  details: ingredient.details,
+                  status: ingredient.status,
+                  onEdit: () {},
+                  onDelete: () {},
+                ),
+              ),
             ),
             const SizedBox(height: 10),
-            PantryItemCard(
-              name: 'Cherry Tomatoes',
-              details: '~10 pcs • Pantry',
-              status: PantryItemStatus.low,
-              onEdit: () {},
-            ),
-            const SizedBox(height: 12),
-            PantryItemCard(
-              name: 'Baby Spinach',
-              details: '200g • Expired 2 days ago',
-              status: PantryItemStatus.expired,
-              onDelete: () {},
-            ),
-            const SizedBox(height: 22),
-            const AppSectionHeader(
-              title: 'Dairy',
-              trailing: '2 ITEMS',
-              showAccentLine: false,
-            ),
-            const SizedBox(height: 10),
-            PantryItemCard(
-              name: 'Parmesan Cheese',
-              details: '150g • Wedge',
-              status: PantryItemStatus.fresh,
-              onEdit: () {},
-            ),
-            const SizedBox(height: 12),
-            PantryItemCard(
-              name: 'Full Cream Milk',
-              details: '1L • Carton',
-              status: PantryItemStatus.low,
-              onEdit: () {},
-            ),
           ],
         ),
+      ],
+    );
+  }
+}
+
+//pantry rows grouped by categories
+Map<String, List<PantryIngredient>> _groupIngredientsByCategory(
+  List<PantryIngredient> ingredients,
+) {
+  final grouped = <String, List<PantryIngredient>>{};
+
+  for (final ingredient in ingredients) {
+    grouped.putIfAbsent(ingredient.category, () => []);
+    grouped[ingredient.category]!.add(ingredient);
+  }
+
+  return grouped;
+}
+
+class _PantryError extends StatelessWidget {
+  const _PantryError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'Unable to load pantry data.',
+        style: AppTextStyles.body.copyWith(color: AppColors.error),
       ),
     );
   }

--- a/frontend/lib/features/preference/models/user_preferences.dart
+++ b/frontend/lib/features/preference/models/user_preferences.dart
@@ -1,0 +1,44 @@
+//data used by preference profile
+class UserPreferences {
+  const UserPreferences({
+    required this.dietaryDirectives,
+    required this.selectedAllergies,
+    required this.availableAllergies,
+    required this.dislikedIngredients,
+    required this.flavourProfiles,
+  });
+
+  final List<DietaryDirective> dietaryDirectives;
+  final List<String> selectedAllergies;
+  final List<String> availableAllergies;
+  final List<String> dislikedIngredients;
+  final List<FlavourProfile> flavourProfiles;
+}
+
+//user can select dietary restrictions etc
+class DietaryDirective {
+  const DietaryDirective({
+    required this.title,
+    required this.subtitle,
+    this.selected = false,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool selected;
+}
+
+//dashboard for flavour profile
+class FlavourProfile {
+  const FlavourProfile({
+    required this.label,
+    required this.description,
+    required this.iconKey,
+    this.selected = false,
+  });
+
+  final String label;
+  final String description;
+  final String iconKey;
+  final bool selected;
+}

--- a/frontend/lib/features/preference/providers/preference_provider.dart
+++ b/frontend/lib/features/preference/providers/preference_provider.dart
@@ -1,2 +1,23 @@
 // Holds the user's preference profile (dietary restrictions, cuisines, etc.).
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/constants/app_config.dart';
+import '../models/user_preferences.dart';
+import '../repositories/api_preference_repository.dart';
+import '../repositories/mock_preference_repository.dart';
+import '../repositories/preference_repository.dart';
+
+//selects mock/API repo
+final preferenceRepositoryProvider = Provider<PreferenceRepository>((ref) {
+  if (AppConfig.useMockData) {
+    return MockPreferenceRepository();
+  }
+
+  return ApiPreferenceRepository();
+});
+
+//exposes preference profile data
+final userPreferencesProvider = FutureProvider<UserPreferences>((ref) {
+  final repository = ref.watch(preferenceRepositoryProvider);
+  return repository.getUserPreferences();
+});

--- a/frontend/lib/features/preference/repositories/api_preference_repository.dart
+++ b/frontend/lib/features/preference/repositories/api_preference_repository.dart
@@ -1,0 +1,12 @@
+import '../models/user_preferences.dart';
+import 'preference_repository.dart';
+
+//backend data (for future use)
+class ApiPreferenceRepository implements PreferenceRepository {
+  @override
+  Future<UserPreferences> getUserPreferences() {
+    throw UnimplementedError(
+      'Preference API integration has not been implemented yet.',
+    );
+  }
+}

--- a/frontend/lib/features/preference/repositories/mock_preference_repository.dart
+++ b/frontend/lib/features/preference/repositories/mock_preference_repository.dart
@@ -1,0 +1,60 @@
+import '../models/user_preferences.dart';
+import 'preference_repository.dart';
+
+//mock data (while API not connected)
+class MockPreferenceRepository implements PreferenceRepository {
+  @override
+  Future<UserPreferences> getUserPreferences() async {
+    return const UserPreferences(
+      dietaryDirectives: [
+        DietaryDirective(
+          title: 'PLANT-BASED / VEGAN',
+          subtitle: 'Exclusively botanical-led cuisine.',
+        ),
+        DietaryDirective(
+          title: 'CELIAC FRIENDLY / GLUTEN-FREE',
+          subtitle: 'Rigorous gluten-free adherence.',
+          selected: true,
+        ),
+        DietaryDirective(
+          title: 'DAIRY FREE',
+          subtitle: 'Lactose and casein-free alternatives.',
+        ),
+        DietaryDirective(
+          title: 'CARB CONSCIOUS / KETO',
+          subtitle: 'High protein and healthy fats focus.',
+        ),
+      ],
+      selectedAllergies: ['PEANUTS', 'SHELLFISH'],
+      availableAllergies: ['TREE NUTS', 'SOY', 'EGGS'],
+      dislikedIngredients: ['CILANTRO', 'CAPERS', 'BLUE CHEESE'],
+      flavourProfiles: [
+        FlavourProfile(
+          label: 'Mediterranean',
+          description:
+              'Bright herbs, olive oil, citrus, grains, and fresh vegetables.',
+          iconKey: 'mediterranean',
+          selected: true,
+        ),
+        FlavourProfile(
+          label: 'Asian Fusion',
+          description:
+              'Soy, ginger, chilli, sesame, rice bowls, noodles, and umami-rich sauces.',
+          iconKey: 'asian',
+        ),
+        FlavourProfile(
+          label: 'Comfort Classics',
+          description:
+              'Warm, familiar meals with hearty textures and simple pantry staples.',
+          iconKey: 'comfort',
+        ),
+        FlavourProfile(
+          label: 'Fresh & Light',
+          description:
+              'Lean proteins, crisp produce, lighter sauces, and balanced portions.',
+          iconKey: 'fresh',
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/features/preference/repositories/preference_repository.dart
+++ b/frontend/lib/features/preference/repositories/preference_repository.dart
@@ -1,0 +1,6 @@
+import '../models/user_preferences.dart';
+
+//contratc used by mock and API data
+abstract class PreferenceRepository {
+  Future<UserPreferences> getUserPreferences();
+}

--- a/frontend/lib/features/preference/screens/preference_screen.dart
+++ b/frontend/lib/features/preference/screens/preference_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/routes/app_routes.dart';
@@ -8,20 +9,47 @@ import '../../../core/shared_widgets/atoms/app_button.dart';
 import '../../../core/shared_widgets/atoms/app_text_field.dart';
 import '../../../core/theme/app_colours.dart';
 import '../../../core/theme/app_typography.dart';
+import '../models/user_preferences.dart';
+import '../providers/preference_provider.dart';
 import '../widgets/flavour_profile_card.dart';
 import '../widgets/preference_option_card.dart';
 import '../widgets/preference_tag_chip.dart';
 
-class PreferenceScreen extends StatelessWidget {
+//had to put ConsumerWidget to let screen read Riverpod providers 
+class PreferenceScreen extends ConsumerWidget {
   const PreferenceScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    // Temporary mock data until preferences API is connected.
-    final selectedAllergies = ['PEANUTS', 'SHELLFISH'];
-    final availableAllergies = ['TREE NUTS', 'SOY', 'EGGS'];
-    final dislikedIngredients = ['CILANTRO', 'CAPERS', 'BLUE CHEESE'];
+  Widget build(BuildContext context, WidgetRef ref) {
+    //loads mock/API data
+    final preferencesState = ref.watch(userPreferencesProvider);
 
+    //handles the diff states
+    return preferencesState.when(
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (error, stackTrace) => Scaffold(
+        appBar: AppBar(title: const Text('Preference')),
+        body: Center(
+          child: Text(
+            'Unable to load preferences.',
+            style: AppTextStyles.body.copyWith(color: AppColors.error),
+          ),
+        ),
+      ),
+      data: (preferences) => _PreferenceContent(preferences: preferences),
+    );
+  }
+}
+
+class _PreferenceContent extends StatelessWidget {
+  const _PreferenceContent({required this.preferences});
+
+  final UserPreferences preferences;
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.bgLight,
       appBar: AppBar(
@@ -69,27 +97,18 @@ class PreferenceScreen extends StatelessWidget {
             // Dietary selection cards.
             const AppSectionHeader(title: 'Dietary Directives'),
             const SizedBox(height: 14),
-            const PreferenceOptionCard(
-              title: 'PLANT-BASED / VEGAN',
-              subtitle: 'Exclusively botanical-led cuisine.',
+            ...preferences.dietaryDirectives.map(
+              (directive) => Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: PreferenceOptionCard(
+                  title: directive.title,
+                  subtitle: directive.subtitle,
+                  selected: directive.selected,
+                  onTap: () {},
+                ),
+              ),
             ),
-            const SizedBox(height: 10),
-            const PreferenceOptionCard(
-              title: 'CELIAC FRIENDLY / GLUTEN-FREE',
-              subtitle: 'Rigorous gluten-free adherence.',
-              selected: true,
-            ),
-            const SizedBox(height: 10),
-            const PreferenceOptionCard(
-              title: 'DAIRY FREE',
-              subtitle: 'Lactose and casein-free alternatives.',
-            ),
-            const SizedBox(height: 10),
-            const PreferenceOptionCard(
-              title: 'CARB CONSCIOUS / KETO',
-              subtitle: 'High protein and healthy fats focus.',
-            ),
-            const SizedBox(height: 32),
+            const SizedBox(height: 22),
 
             // Allergy and dislike tags.
             const AppSectionHeader(title: 'Critical Allergies'),
@@ -98,14 +117,14 @@ class PreferenceScreen extends StatelessWidget {
               spacing: 10,
               runSpacing: 10,
               children: [
-                ...selectedAllergies.map(
+                ...preferences.selectedAllergies.map(
                   (allergy) => PreferenceTagChip(
                     label: allergy,
                     selected: true,
                     onRemove: () {},
                   ),
                 ),
-                ...availableAllergies.map(
+                ...preferences.availableAllergies.map(
                   (allergy) => PreferenceTagChip(
                     label: allergy,
                     onTap: () {},
@@ -128,7 +147,7 @@ class PreferenceScreen extends StatelessWidget {
             Wrap(
               spacing: 8,
               runSpacing: 8,
-              children: dislikedIngredients
+              children: preferences.dislikedIngredients
                   .map(
                     (ingredient) => PreferenceTagChip(
                       label: ingredient,
@@ -140,34 +159,22 @@ class PreferenceScreen extends StatelessWidget {
             ),
             const SizedBox(height: 28),
 
-            //cuisine preference cards
+            // Cuisine preference cards.
             const AppSectionHeader(title: 'Flavour Profiles'),
             const SizedBox(height: 16),
-            const FlavourProfileCard(
-              label: 'Mediterranean',
-              description: 'Bright herbs, olive oil, citrus, grains, and fresh vegetables.',
-              icon: Icons.local_florist_outlined,
-              selected: true,
+            ...preferences.flavourProfiles.map(
+              (profile) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: FlavourProfileCard(
+                  label: profile.label,
+                  description: profile.description,
+                  icon: _iconForFlavourProfile(profile.iconKey),
+                  selected: profile.selected,
+                  onTap: () {},
+                ),
+              ),
             ),
-            const SizedBox(height: 12),
-            const FlavourProfileCard(
-              label: 'Asian Fusion',
-              description: 'Soy, ginger, chilli, sesame, rice bowls, noodles, and umami-rich sauces.',
-              icon: Icons.ramen_dining_outlined,
-            ),
-            const SizedBox(height: 12),
-            const FlavourProfileCard(
-              label: 'Comfort Classics',
-              description: 'Warm, familiar meals with hearty textures and simple pantry staples.',
-              icon: Icons.soup_kitchen_outlined,
-            ),
-            const SizedBox(height: 12),
-            const FlavourProfileCard(
-              label: 'Fresh & Light',
-              description: 'Lean proteins, crisp produce, lighter sauces, and balanced portions.',
-              icon: Icons.eco_outlined,
-            ),
-            const SizedBox(height: 40),
+            const SizedBox(height: 28),
             AppButton(
               label: 'Update Profile',
               onPressed: () {},
@@ -182,4 +189,15 @@ class PreferenceScreen extends StatelessWidget {
       ),
     );
   }
+}
+
+// Maps mock/API icon keys to visual icons.
+IconData _iconForFlavourProfile(String iconKey) {
+  return switch (iconKey) {
+    'mediterranean' => Icons.local_florist_outlined,
+    'asian' => Icons.ramen_dining_outlined,
+    'comfort' => Icons.soup_kitchen_outlined,
+    'fresh' => Icons.eco_outlined,
+    _ => Icons.restaurant_menu_outlined,
+  };
 }

--- a/frontend/test/features/pantry/providers/pantry_provider_test.dart
+++ b/frontend/test/features/pantry/providers/pantry_provider_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mealchemy/features/pantry/providers/pantry_provider.dart';
+import 'package:mealchemy/features/pantry/repositories/mock_pantry_repository.dart';
+
+void main() {
+  test('pantryRepositoryProvider uses mock repository', () {
+    //create Riverpod provider container for isolated testing
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final repository = container.read(pantryRepositoryProvider);
+
+    expect(repository, isA<MockPantryRepository>());
+  });
+}

--- a/frontend/test/features/pantry/providers/pantry_provider_test.dart
+++ b/frontend/test/features/pantry/providers/pantry_provider_test.dart
@@ -13,4 +13,19 @@ void main() {
 
     expect(repository, isA<MockPantryRepository>());
   });
+
+  test('pantry providers expose mock pantry data', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final summary = await container.read(pantrySummaryProvider.future);
+    final filters = await container.read(pantryFiltersProvider.future);
+    final ingredients = await container.read(pantryIngredientsProvider.future);
+    final categories = await container.read(ingredientCategoriesProvider.future);
+
+    expect(summary.totalItems, 42);
+    expect(filters.first.label, 'All');
+    expect(ingredients.first.name, 'Chicken Breast');
+    expect(categories, contains('produce'));
+  });
 }

--- a/frontend/test/features/pantry/repositories/api_pantry_repository_test.dart
+++ b/frontend/test/features/pantry/repositories/api_pantry_repository_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mealchemy/features/pantry/repositories/api_pantry_repository.dart';
+
+void main() {
+  //throw
+  test('ApiPantryRepository throws for summary until API is implemented', () {
+    //create repo instance
+    final repository = ApiPantryRepository();
+
+    expect(repository.getPantrySummary, throwsA(isA<UnimplementedError>()));
+  });
+
+  test('ApiPantryRepository throws for filters until API is implemented', () {
+    final repository = ApiPantryRepository();
+
+    //ensure it fails (not returning invalid data)
+    expect(repository.getPantryFilters, throwsA(isA<UnimplementedError>()));
+  });
+
+  test('ApiPantryRepository throws for ingredients until API is implemented', () {
+    final repository = ApiPantryRepository();
+
+    expect(repository.getPantryIngredients, throwsA(isA<UnimplementedError>()));
+  });
+
+  test('ApiPantryRepository throws for categories until API is implemented', () {
+    final repository = ApiPantryRepository();
+
+    expect(repository.getIngredientCategories, throwsA(isA<UnimplementedError>()));
+  });
+}

--- a/frontend/test/features/pantry/repositories/mock_pantry_repository_test.dart
+++ b/frontend/test/features/pantry/repositories/mock_pantry_repository_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mealchemy/features/pantry/repositories/mock_pantry_repository.dart';
+import 'package:mealchemy/features/pantry/widgets/pantry_item_card.dart';
+
+void main() {
+  //ensure mock data returns
+  test('MockPantryRepository returns pantry summary data', () async {
+    //mock repo instance
+    final repository = MockPantryRepository();
+
+    final summary = await repository.getPantrySummary();
+
+    expect(summary.totalItems, 42);
+    expect(summary.freshnessPercent, 84);
+    expect(summary.optimizationPercent, 72);
+  });
+
+  //ingredients returned correctly (details)
+  test('MockPantryRepository returns pantry ingredients', () async {
+    final repository = MockPantryRepository();
+
+    //fetch mock data
+    final ingredients = await repository.getPantryIngredients();
+
+    expect(ingredients, isNotEmpty);
+    expect(ingredients.first.name, 'Chicken Breast');
+    expect(ingredients.first.status, PantryItemStatus.fresh);
+  });
+
+  //expected category data
+  test('MockPantryRepository returns ingredient categories', () async {
+    final repository = MockPantryRepository();
+
+    final categories = await repository.getIngredientCategories();
+
+    expect(categories, contains('produce'));
+    expect(categories, contains('dairy'));
+    expect(categories, contains('other'));
+  });
+}

--- a/frontend/test/features/pantry/screens/add_ingredient_screen_test.dart
+++ b/frontend/test/features/pantry/screens/add_ingredient_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mealchemy/features/pantry/screens/add_ingredient_screen.dart';
@@ -12,10 +13,16 @@ void main() {
     tester,
   ) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: AddIngredientScreen(),
+      //need provider scope because screen reads Riverpod providers
+      const ProviderScope(
+        child: MaterialApp(
+          home: AddIngredientScreen(),
+        ),
       ),
     );
+
+    //waits for mock data to load
+    await tester.pumpAndSettle();
 
     expect(find.text('Add Ingredient\nManually'), findsOneWidget);
     expect(find.text('Ingredient Details'), findsOneWidget);

--- a/frontend/test/features/pantry/screens/pantry_error_test.dart
+++ b/frontend/test/features/pantry/screens/pantry_error_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/features/pantry/models/pantry_ingredient.dart';
+import 'package:mealchemy/features/pantry/models/pantry_summary.dart';
+import 'package:mealchemy/features/pantry/providers/pantry_provider.dart';
+import 'package:mealchemy/features/pantry/repositories/pantry_repository.dart';
+import 'package:mealchemy/features/pantry/screens/add_ingredient_screen.dart';
+import 'package:mealchemy/features/pantry/screens/pantry_screen.dart';
+
+//mock repo to simulate pantry API
+class _FailingPantryRepository implements PantryRepository {
+  @override
+  //simulate different failures
+  Future<PantrySummary> getPantrySummary() {
+    throw Exception('Summary failure');
+  }
+
+  @override
+  Future<List<PantryFilter>> getPantryFilters() {
+    throw Exception('Filter failure');
+  }
+
+  @override
+  Future<List<PantryIngredient>> getPantryIngredients() {
+    throw Exception('Ingredient failure');
+  }
+
+  @override
+  Future<List<String>> getIngredientCategories() {
+    throw Exception('Category failure');
+  }
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('PantryScreen renders error state', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          pantryRepositoryProvider.overrideWithValue(_FailingPantryRepository()),
+        ],
+        child: const MaterialApp(
+          home: PantryScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unable to load pantry data.'), findsOneWidget);
+  });
+
+  testWidgets('AddIngredientScreen renders category error state', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          pantryRepositoryProvider.overrideWithValue(_FailingPantryRepository()),
+        ],
+        child: const MaterialApp(
+          home: AddIngredientScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unable to load ingredient categories.'), findsOneWidget);
+  });
+}

--- a/frontend/test/features/pantry/screens/pantry_test.dart
+++ b/frontend/test/features/pantry/screens/pantry_test.dart
@@ -1,20 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mealchemy/features/pantry/screens/pantry_screen.dart';
 
 void main() {
   setUpAll(() {
+    //disable fonts during tests
     GoogleFonts.config.allowRuntimeFetching = false;
   });
 
+  //make sure renders everything
   testWidgets('PantryScreen renders pantry overview', (tester) async {
+    //wrapping screen
     await tester.pumpWidget(
-      const MaterialApp(
-        home: PantryScreen(),
+      const ProviderScope(
+        child: MaterialApp(
+          home: PantryScreen(),
+        ),
       ),
     );
 
+    await tester.pumpAndSettle();
+
+    //make sure displays 
     expect(find.text('Pantry'), findsWidgets);
     expect(find.text('Meal Optimization'), findsOneWidget);
     expect(find.text('Proteins'), findsOneWidget);

--- a/frontend/test/features/preference/providers/preference_provider_test.dart
+++ b/frontend/test/features/preference/providers/preference_provider_test.dart
@@ -16,4 +16,14 @@ void main() {
     //using mock repo
     expect(repository, isA<MockPreferenceRepository>());
   });
+
+  test('userPreferencesProvider exposes mock preference data', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final preferences = await container.read(userPreferencesProvider.future);
+
+    expect(preferences.selectedAllergies, contains('PEANUTS'));
+    expect(preferences.flavourProfiles.first.selected, isTrue);
+  });
 }

--- a/frontend/test/features/preference/providers/preference_provider_test.dart
+++ b/frontend/test/features/preference/providers/preference_provider_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mealchemy/features/preference/providers/preference_provider.dart';
+import 'package:mealchemy/features/preference/repositories/mock_preference_repository.dart';
+
+void main() {
+  //uses mock repo
+  test('preferenceRepositoryProvider uses mock repository', () {
+    //create Riverpod provider container for isolated testing
+    final container = ProviderContainer();
+    //delete container
+    addTearDown(container.dispose);
+
+    final repository = container.read(preferenceRepositoryProvider);
+
+    //using mock repo
+    expect(repository, isA<MockPreferenceRepository>());
+  });
+}

--- a/frontend/test/features/preference/repositories/api_preference_repository_test.dart
+++ b/frontend/test/features/preference/repositories/api_preference_repository_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mealchemy/features/preference/repositories/api_preference_repository.dart';
+
+void main() {
+  test('ApiPreferenceRepository throws until API integration is implemented', () {
+    //create repo instance
+    final repository = ApiPreferenceRepository();
+
+    //ensure it fails
+    expect(
+      repository.getUserPreferences,
+      throwsA(isA<UnimplementedError>()),
+    );
+  });
+}

--- a/frontend/test/features/preference/repositories/mock_preference_repository_test.dart
+++ b/frontend/test/features/preference/repositories/mock_preference_repository_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mealchemy/features/preference/repositories/mock_preference_repository.dart';
+
+void main() {
+  //make sure it actually returns mock data
+  test('MockPreferenceRepository returns preference profile data', () async {
+    //mock repo instance (no API)
+    final repository = MockPreferenceRepository();
+
+    final preferences = await repository.getUserPreferences();
+
+    //expected mock data
+    expect(preferences.dietaryDirectives, isNotEmpty);
+    expect(preferences.selectedAllergies, contains('PEANUTS'));
+    expect(preferences.dislikedIngredients, contains('CILANTRO'));
+    expect(preferences.flavourProfiles.first.selected, isTrue);
+  });
+}

--- a/frontend/test/features/preference/screens/preference_error_test.dart
+++ b/frontend/test/features/preference/screens/preference_error_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/features/preference/models/user_preferences.dart';
+import 'package:mealchemy/features/preference/providers/preference_provider.dart';
+import 'package:mealchemy/features/preference/repositories/preference_repository.dart';
+import 'package:mealchemy/features/preference/screens/preference_screen.dart';
+
+//mock repo to similate API calls
+class _FailingPreferenceRepository implements PreferenceRepository {
+  @override
+  //simulate repo failure
+  Future<UserPreferences> getUserPreferences() {
+    throw Exception('Preference failure');
+  }
+}
+
+void main() {
+  //disable font fetching
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  //dislays correct error state
+  testWidgets('PreferenceScreen renders error state', (tester) async {
+    //context required
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          preferenceRepositoryProvider.overrideWithValue(
+            _FailingPreferenceRepository(),
+          ),
+        ],
+        child: const MaterialApp(
+          home: PreferenceScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unable to load preferences.'), findsOneWidget);
+  });
+}

--- a/frontend/test/features/preference/screens/preference_test.dart
+++ b/frontend/test/features/preference/screens/preference_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mealchemy/features/preference/screens/preference_screen.dart';
 
@@ -10,10 +11,16 @@ void main() {
 
   testWidgets('PreferenceScreen renders preference overview', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: PreferenceScreen(),
+      //need provider scope because screen reads Riverpod providers
+      const ProviderScope(
+        child: MaterialApp(
+          home: PreferenceScreen(),
+        ),
       ),
     );
+
+    //waits for mock data to finish loading
+    await tester.pumpAndSettle();
 
     expect(find.text('Bespoke Culinary\nProfile'), findsOneWidget);
     expect(find.text('Dietary Directives'), findsOneWidget);


### PR DESCRIPTION
What changed:

Mock Data Pattern:
Added mock data repository structure for the Preference Profile and Pantry use cases.
Screens now consume provider-backed mock data instead of hardcoded values directly inside the widgets.

Preference Profile:
Added UserPreferences, DietaryDirective, and FlavourProfile models
Added preference repository interface, mock repository, and API placeholder
Updated PreferenceScreen to consume userPreferencesProvider

Pantry:
Added PantryIngredient, PantrySummary, and PantryFilter models
Added pantry repository interface, mock repository, and API placeholder
Updated PantryScreen to consume pantry summary, filter, and ingredient providers
Updated AddIngredientScreen to consume ingredient category data from the pantry provider

Tests:
Added tests for mock preference and pantry repositories
Added provider tests for repository selection
Updated screen tests to support Riverpod ProviderScope and async mock data loading

Notes:
API repositories are placeholders for future backend integration
AppConfig.useMockData currently controls whether mock or API repositories are selected
Mock data is intentionally small and only supports screen rendering during parallel development