### PR TITLE
Feature/interactions/sofia finlayson

### DIFF
--- a/frontend/lib/features/pantry/models/pantry_ingredient.dart
+++ b/frontend/lib/features/pantry/models/pantry_ingredient.dart
@@ -13,4 +13,19 @@ class PantryIngredient {
   final String details;
   final String category;
   final PantryItemStatus status;
+
+  //creates updated ingredient without changing original
+  PantryIngredient copyWith({
+    String? name,
+    String? details,
+    String? category,
+    PantryItemStatus? status,
+  }) {
+    return PantryIngredient(
+      name: name ?? this.name,
+      details: details ?? this.details,
+      category: category ?? this.category,
+      status: status ?? this.status,
+    );
+  }
 }

--- a/frontend/lib/features/pantry/models/pantry_summary.dart
+++ b/frontend/lib/features/pantry/models/pantry_summary.dart
@@ -1,3 +1,5 @@
+import 'pantry_ingredient.dart';
+
 //summaries at the top of pantry page (freshness, categories, etc)
 class PantrySummary {
   const PantrySummary({
@@ -22,4 +24,42 @@ class PantryFilter {
 
   final String label;
   final int count;
+}
+
+//editable pantry state
+class PantryState {
+  const PantryState({
+    required this.summary,
+    required this.filters,
+    required this.ingredients,
+    required this.categories,
+    this.selectedFilter = 'All',
+    this.searchQuery = '',
+  });
+
+  final PantrySummary summary;
+  final List<PantryFilter> filters;
+  final List<PantryIngredient> ingredients;
+  final List<String> categories;
+  final String selectedFilter;
+  final String searchQuery;
+
+  //pantry updates unchangeable
+  PantryState copyWith({
+    PantrySummary? summary,
+    List<PantryFilter>? filters,
+    List<PantryIngredient>? ingredients,
+    List<String>? categories,
+    String? selectedFilter,
+    String? searchQuery,
+  }) {
+    return PantryState(
+      summary: summary ?? this.summary,
+      filters: filters ?? this.filters,
+      ingredients: ingredients ?? this.ingredients,
+      categories: categories ?? this.categories,
+      selectedFilter: selectedFilter ?? this.selectedFilter,
+      searchQuery: searchQuery ?? this.searchQuery,
+    );
+  }
 }

--- a/frontend/lib/features/pantry/providers/pantry_provider.dart
+++ b/frontend/lib/features/pantry/providers/pantry_provider.dart
@@ -7,6 +7,7 @@ import '../models/pantry_summary.dart';
 import '../repositories/api_pantry_repository.dart';
 import '../repositories/mock_pantry_repository.dart';
 import '../repositories/pantry_repository.dart';
+import '../widgets/pantry_item_card.dart';
 
 //selects mock/API repo
 final pantryRepositoryProvider = Provider<PantryRepository>((ref) {
@@ -17,26 +18,95 @@ final pantryRepositoryProvider = Provider<PantryRepository>((ref) {
   return ApiPantryRepository();
 });
 
-//pantry summaries
-final pantrySummaryProvider = FutureProvider<PantrySummary>((ref) {
-  final repository = ref.watch(pantryRepositoryProvider);
-  return repository.getPantrySummary();
+//editable pantry screen
+final pantryStateProvider = AsyncNotifierProvider<PantryNotifier, PantryState>(
+  PantryNotifier.new,
+);
+
+class PantryNotifier extends AsyncNotifier<PantryState> {
+  late final PantryRepository _repository;
+
+  @override
+  Future<PantryState> build() async {
+    _repository = ref.watch(pantryRepositoryProvider);
+
+    final summary = await _repository.getPantrySummary();
+    final filters = await _repository.getPantryFilters();
+    final ingredients = await _repository.getPantryIngredients();
+    final categories = await _repository.getIngredientCategories();
+
+    return PantryState(
+      summary: summary,
+      filters: filters,
+      ingredients: ingredients,
+      categories: categories,
+    );
+  }
+
+  //filtering
+  void selectFilter(String filterLabel) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    state = AsyncData(current.copyWith(selectedFilter: filterLabel));
+  }
+
+  //searching
+  void updateSearchQuery(String query) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    state = AsyncData(current.copyWith(searchQuery: query.trim()));
+  }
+
+  //clears search
+  void clearSearch() {
+    updateSearchQuery('');
+  }
+
+  //out of stock
+  void markOutOfStock(String ingredientName) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    final updatedIngredients = current.ingredients.map((ingredient) {
+      if (ingredient.name != ingredientName) return ingredient;
+      return ingredient.copyWith(status: PantryItemStatus.expired);
+    }).toList();
+
+    state = AsyncData(current.copyWith(ingredients: updatedIngredients));
+  }
+
+  //removes ingredient from pantry list
+  void removeIngredient(String ingredientName) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    final updatedIngredients = current.ingredients
+        .where((ingredient) => ingredient.name != ingredientName)
+        .toList();
+
+    state = AsyncData(current.copyWith(ingredients: updatedIngredients));
+  }
+}
+
+final pantrySummaryProvider = FutureProvider<PantrySummary>((ref) async {
+  final pantryState = await ref.watch(pantryStateProvider.future);
+  return pantryState.summary;
 });
 
-//pantry filtering
-final pantryFiltersProvider = FutureProvider<List<PantryFilter>>((ref) {
-  final repository = ref.watch(pantryRepositoryProvider);
-  return repository.getPantryFilters();
+final pantryFiltersProvider = FutureProvider<List<PantryFilter>>((ref) async {
+  final pantryState = await ref.watch(pantryStateProvider.future);
+  return pantryState.filters;
 });
 
-//pantry ingredients
-final pantryIngredientsProvider = FutureProvider<List<PantryIngredient>>((ref) {
-  final repository = ref.watch(pantryRepositoryProvider);
-  return repository.getPantryIngredients();
+final pantryIngredientsProvider =
+    FutureProvider<List<PantryIngredient>>((ref) async {
+  final pantryState = await ref.watch(pantryStateProvider.future);
+  return pantryState.ingredients;
 });
 
-//ingredient categories (user adds)
-final ingredientCategoriesProvider = FutureProvider<List<String>>((ref) {
-  final repository = ref.watch(pantryRepositoryProvider);
-  return repository.getIngredientCategories();
+final ingredientCategoriesProvider = FutureProvider<List<String>>((ref) async {
+  final pantryState = await ref.watch(pantryStateProvider.future);
+  return pantryState.categories;
 });

--- a/frontend/lib/features/pantry/providers/pantry_provider.dart
+++ b/frontend/lib/features/pantry/providers/pantry_provider.dart
@@ -77,6 +77,41 @@ class PantryNotifier extends AsyncNotifier<PantryState> {
     state = AsyncData(current.copyWith(ingredients: updatedIngredients));
   }
 
+  //adds ingredient to pantry
+  void addIngredient({
+    required String name,
+    required String quantity,
+    required String unit,
+    required String category,
+    required bool isOutOfStock,
+  }) {
+    final current = state.valueOrNull;
+    final cleanedName = name.trim();
+    final cleanedQuantity = quantity.trim();
+    final cleanedUnit = unit.trim();
+
+    if (current == null ||
+        cleanedName.isEmpty ||
+        cleanedQuantity.isEmpty ||
+        cleanedUnit.isEmpty) {
+      return;
+    }
+
+    final displayCategory = _displayCategory(category);
+    final newIngredient = PantryIngredient(
+      name: cleanedName,
+      details: '$cleanedQuantity$cleanedUnit • Manual entry',
+      category: displayCategory,
+      status: isOutOfStock ? PantryItemStatus.expired : PantryItemStatus.fresh,
+    );
+
+    state = AsyncData(
+      current.copyWith(
+        ingredients: [...current.ingredients, newIngredient],
+      ),
+    );
+  }
+
   //removes ingredient from pantry list
   void removeIngredient(String ingredientName) {
     final current = state.valueOrNull;
@@ -110,3 +145,13 @@ final ingredientCategoriesProvider = FutureProvider<List<String>>((ref) async {
   final pantryState = await ref.watch(pantryStateProvider.future);
   return pantryState.categories;
 });
+
+//changes enum values
+String _displayCategory(String category) {
+  return switch (category) {
+    'meat' || 'poultry' || 'seafood' => 'Proteins',
+    'produce' => 'Vegetables',
+    'dairy' => 'Dairy',
+    _ => 'Other',
+  };
+}

--- a/frontend/lib/features/pantry/screens/add_ingredient_screen.dart
+++ b/frontend/lib/features/pantry/screens/add_ingredient_screen.dart
@@ -38,13 +38,41 @@ class AddIngredientScreen extends ConsumerWidget {
   }
 }
 
-class _AddIngredientContent extends StatelessWidget {
+class _AddIngredientContent extends ConsumerStatefulWidget {
   const _AddIngredientContent({required this.categories});
 
   final List<String> categories;
 
   @override
+  ConsumerState<_AddIngredientContent> createState() =>
+      _AddIngredientContentState();
+}
+
+class _AddIngredientContentState extends ConsumerState<_AddIngredientContent> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _quantityController = TextEditingController();
+  final TextEditingController _unitController = TextEditingController();
+  final TextEditingController _priceController = TextEditingController();
+
+  String _selectedCategory = 'produce';
+  bool _isOutOfStock = false;
+  bool _showValidation = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _quantityController.dispose();
+    _unitController.dispose();
+    _priceController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final hasName = _nameController.text.trim().isNotEmpty;
+    final hasQuantity = _quantityController.text.trim().isNotEmpty;
+    final hasUnit = _unitController.text.trim().isNotEmpty;
+
     return ListView(
       padding: const EdgeInsets.fromLTRB(20, 18, 20, 28),
       children: [
@@ -77,43 +105,59 @@ class _AddIngredientContent extends StatelessWidget {
         const AppSectionHeader(title: 'Ingredient Details'),
         const SizedBox(height: 14),
         AppTextField(
+          controller: _nameController,
           label: 'Ingredient name',
           hint: 'e.g. Chicken breast',
-          onChanged: (_) {},
+          onChanged: (_) => setState(() {}),
         ),
+        if (_showValidation && !hasName)
+          const _ValidationText('Ingredient name is required.'),
         const SizedBox(height: 14),
-        _CategorySelector(categories: categories),
+        _CategorySelector(
+          categories: widget.categories,
+          selectedCategory: _selectedCategory,
+          onSelected: (category) {
+            setState(() {
+              _selectedCategory = category;
+            });
+          },
+        ),
         const SizedBox(height: 28),
 
-        //amount + units
+        //amount and units
         const AppSectionHeader(title: 'Quantity'),
         const SizedBox(height: 14),
         Row(
           children: [
             Expanded(
               child: AppTextField(
+                controller: _quantityController,
                 label: 'Quantity',
                 hint: 'e.g. 800',
                 keyboardType: TextInputType.number,
-                onChanged: (_) {},
+                onChanged: (_) => setState(() {}),
               ),
             ),
             const SizedBox(width: 12),
             Expanded(
               child: AppTextField(
+                controller: _unitController,
                 label: 'Unit',
                 hint: 'g, ml, cups',
-                onChanged: (_) {},
+                onChanged: (_) => setState(() {}),
               ),
             ),
-          ], // ← Row closes here
+          ],
         ),
+        if (_showValidation && (!hasQuantity || !hasUnit))
+          const _ValidationText('Quantity and unit are required.'),
         const SizedBox(height: 28),
 
         //purchase details
         const AppSectionHeader(title: 'Purchase Info'),
         const SizedBox(height: 14),
         AppTextField(
+          controller: _priceController,
           label: 'Price paid',
           hint: 'e.g. 89.99',
           keyboardType: TextInputType.number,
@@ -122,35 +166,64 @@ class _AddIngredientContent extends StatelessWidget {
         ),
         const SizedBox(height: 28),
         _StockToggle(
-          value: false,
-          onChanged: (_) {},
+          value: _isOutOfStock,
+          onChanged: (value) {
+            setState(() {
+              _isOutOfStock = value;
+            });
+          },
         ),
         const SizedBox(height: 36),
-        AppButton.primary(
+        AppButton(
           label: 'Save Ingredient',
-          onPressed: () {},
-          isFullWidth: true,
+          onPressed: _saveIngredient,
         ),
         const SizedBox(height: 14),
-        AppButton.outlined(
+        AppButton(
           label: 'Cancel',
           onPressed: () => context.pop(),
-          isFullWidth: true,
         ),
       ],
     );
   }
+
+  void _saveIngredient() {
+    final hasRequiredFields = _nameController.text.trim().isNotEmpty &&
+        _quantityController.text.trim().isNotEmpty &&
+        _unitController.text.trim().isNotEmpty;
+
+    if (!hasRequiredFields) {
+      setState(() {
+        _showValidation = true;
+      });
+      return;
+    }
+
+    ref.read(pantryStateProvider.notifier).addIngredient(
+          name: _nameController.text,
+          quantity: _quantityController.text,
+          unit: _unitController.text,
+          category: _selectedCategory,
+          isOutOfStock: _isOutOfStock,
+        );
+
+    context.pop();
+  }
 }
 
 class _CategorySelector extends StatelessWidget {
-  const _CategorySelector({required this.categories});
+  const _CategorySelector({
+    required this.categories,
+    required this.selectedCategory,
+    required this.onSelected,
+  });
 
   final List<String> categories;
+  final String selectedCategory;
+  final ValueChanged<String> onSelected;
 
   @override
   Widget build(BuildContext context) {
-    const selectedCategory = 'produce';
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -170,7 +243,7 @@ class _CategorySelector extends StatelessWidget {
             return ChoiceChip(
               label: Text(category.toUpperCase()),
               selected: selected,
-              onSelected: (_) {},
+              onSelected: (_) => onSelected(category),
               selectedColor: AppColors.primary,
               backgroundColor: AppColors.surfaceLight,
               labelStyle: AppTextStyles.label.copyWith(
@@ -219,6 +292,23 @@ class _StockToggle extends StatelessWidget {
         style: AppTextStyles.bodySmall.copyWith(
           color: AppColors.textMuted,
         ),
+      ),
+    );
+  }
+}
+
+class _ValidationText extends StatelessWidget {
+  const _ValidationText(this.message);
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Text(
+        message,
+        style: AppTextStyles.bodySmall.copyWith(color: AppColors.error),
       ),
     );
   }

--- a/frontend/lib/features/pantry/screens/pantry_screen.dart
+++ b/frontend/lib/features/pantry/screens/pantry_screen.dart
@@ -21,9 +21,7 @@ class PantryScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final summaryState = ref.watch(pantrySummaryProvider);
-    final filtersState = ref.watch(pantryFiltersProvider);
-    final ingredientsState = ref.watch(pantryIngredientsProvider);
+    final pantryState = ref.watch(pantryStateProvider);
 
     return Scaffold(
       backgroundColor: AppColors.bgLight,
@@ -53,50 +51,34 @@ class PantryScreen extends ConsumerWidget {
         child: const Icon(Icons.add),
       ),
       body: SafeArea(
-        child: summaryState.when(
+        child: pantryState.when(
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (error, stackTrace) => _PantryError(message: '$error'),
-          data: (summary) => filtersState.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (error, stackTrace) => _PantryError(message: '$error'),
-            data: (filters) => ingredientsState.when(
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, stackTrace) => _PantryError(message: '$error'),
-              data: (ingredients) => _PantryContent(
-                summary: summary,
-                filters: filters,
-                ingredients: ingredients,
-              ),
-            ),
-          ),
+          data: (state) => _PantryContent(pantryState: state),
         ),
       ),
     );
   }
 }
 
-class _PantryContent extends StatelessWidget {
-  const _PantryContent({
-    required this.summary,
-    required this.filters,
-    required this.ingredients,
-  });
+class _PantryContent extends ConsumerWidget {
+  const _PantryContent({required this.pantryState});
 
-  final PantrySummary summary;
-  final List<PantryFilter> filters;
-  final List<PantryIngredient> ingredients;
+  final PantryState pantryState;
 
   @override
-  Widget build(BuildContext context) {
-    final groupedIngredients = _groupIngredientsByCategory(ingredients);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pantryNotifier = ref.read(pantryStateProvider.notifier);
+    final visibleIngredients = _visibleIngredients(pantryState);
+    final groupedIngredients = _groupIngredientsByCategory(visibleIngredients);
 
     return ListView(
       padding: const EdgeInsets.fromLTRB(20, 10, 20, 28),
       children: [
         AppSearchBar(
           hint: 'Search pantry...',
-          onChanged: (_) {},
-          onClear: () {},
+          onChanged: pantryNotifier.updateSearchQuery,
+          onClear: pantryNotifier.clearSearch,
         ),
         const SizedBox(height: 18),
         Text(
@@ -107,7 +89,7 @@ class _PantryContent extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         AppFilterBar(
-          options: filters
+          options: pantryState.filters
               .map(
                 (filter) => AppFilterOption(
                   label: filter.label,
@@ -115,49 +97,72 @@ class _PantryContent extends StatelessWidget {
                 ),
               )
               .toList(),
-          selectedIndex: 0,
-          onSelected: (_) {},
+          selectedIndex: _selectedFilterIndex(pantryState),
+          onSelected: (index) => pantryNotifier.selectFilter(
+            pantryState.filters[index].label,
+          ),
         ),
         const SizedBox(height: 22),
         PantrySummaryCard(
-          totalItems: summary.totalItems,
-          freshnessPercent: summary.freshnessPercent,
-          categoryCount: summary.categoryCount,
-          optimizationPercent: summary.optimizationPercent,
+          totalItems: pantryState.summary.totalItems,
+          freshnessPercent: pantryState.summary.freshnessPercent,
+          categoryCount: pantryState.summary.categoryCount,
+          optimizationPercent: pantryState.summary.optimizationPercent,
         ),
         const SizedBox(height: 26),
         AppSectionHeader(
           title: 'Items',
-          trailing: '${summary.totalItems} ITEMS',
+          trailing: '${visibleIngredients.length} ITEMS',
           showAccentLine: false,
         ),
         const SizedBox(height: 18),
-        ...groupedIngredients.entries.expand(
-          (entry) => [
-            AppSectionHeader(
-              title: entry.key,
-              trailing: '${entry.value.length} ITEMS',
-              showAccentLine: false,
-            ),
-            const SizedBox(height: 10),
-            ...entry.value.map(
-              (ingredient) => Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: PantryItemCard(
-                  name: ingredient.name,
-                  details: ingredient.details,
-                  status: ingredient.status,
-                  onEdit: () {},
-                  onDelete: () {},
+        if (visibleIngredients.isEmpty)
+          _EmptyPantryResults(query: pantryState.searchQuery)
+        else
+          ...groupedIngredients.entries.expand(
+            (entry) => [
+              AppSectionHeader(
+                title: entry.key,
+                trailing: '${entry.value.length} ITEMS',
+                showAccentLine: false,
+              ),
+              const SizedBox(height: 10),
+              ...entry.value.map(
+                (ingredient) => Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: PantryItemCard(
+                    name: ingredient.name,
+                    details: ingredient.details,
+                    status: ingredient.status,
+                    onEdit: () => pantryNotifier.markOutOfStock(
+                      ingredient.name,
+                    ),
+                    onDelete: () => pantryNotifier.removeIngredient(
+                      ingredient.name,
+                    ),
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 10),
-          ],
-        ),
+              const SizedBox(height: 10),
+            ],
+          ),
       ],
     );
   }
+}
+
+//category and search filters
+List<PantryIngredient> _visibleIngredients(PantryState pantryState) {
+  final query = pantryState.searchQuery.toLowerCase();
+
+  return pantryState.ingredients.where((ingredient) {
+    final matchesFilter = pantryState.selectedFilter == 'All' ||
+        ingredient.category == pantryState.selectedFilter;
+    final matchesSearch =
+        query.isEmpty || ingredient.name.toLowerCase().contains(query);
+
+    return matchesFilter && matchesSearch;
+  }).toList();
 }
 
 //pantry rows grouped by categories
@@ -172,6 +177,36 @@ Map<String, List<PantryIngredient>> _groupIngredientsByCategory(
   }
 
   return grouped;
+}
+
+int _selectedFilterIndex(PantryState pantryState) {
+  final index = pantryState.filters.indexWhere(
+    (filter) => filter.label == pantryState.selectedFilter,
+  );
+
+  return index < 0 ? 0 : index;
+}
+
+class _EmptyPantryResults extends StatelessWidget {
+  const _EmptyPantryResults({required this.query});
+
+  final String query;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = query.isEmpty
+        ? 'No pantry ingredients found.'
+        : 'No ingredients match "$query".';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 28),
+      child: Text(
+        message,
+        textAlign: TextAlign.center,
+        style: AppTextStyles.body.copyWith(color: AppColors.textMuted),
+      ),
+    );
+  }
 }
 
 class _PantryError extends StatelessWidget {

--- a/frontend/lib/features/preference/models/user_preferences.dart
+++ b/frontend/lib/features/preference/models/user_preferences.dart
@@ -13,9 +13,26 @@ class UserPreferences {
   final List<String> availableAllergies;
   final List<String> dislikedIngredients;
   final List<FlavourProfile> flavourProfiles;
+
+  //creates updated copy and keeps unchanged
+  UserPreferences copyWith({
+    List<DietaryDirective>? dietaryDirectives,
+    List<String>? selectedAllergies,
+    List<String>? availableAllergies,
+    List<String>? dislikedIngredients,
+    List<FlavourProfile>? flavourProfiles,
+  }) {
+    return UserPreferences(
+      dietaryDirectives: dietaryDirectives ?? this.dietaryDirectives,
+      selectedAllergies: selectedAllergies ?? this.selectedAllergies,
+      availableAllergies: availableAllergies ?? this.availableAllergies,
+      dislikedIngredients: dislikedIngredients ?? this.dislikedIngredients,
+      flavourProfiles: flavourProfiles ?? this.flavourProfiles,
+    );
+  }
 }
 
-//user can select dietary restrictions etc
+//select dietary restrictions
 class DietaryDirective {
   const DietaryDirective({
     required this.title,
@@ -26,9 +43,22 @@ class DietaryDirective {
   final String title;
   final String subtitle;
   final bool selected;
+
+  //selected state
+  DietaryDirective copyWith({
+    String? title,
+    String? subtitle,
+    bool? selected,
+  }) {
+    return DietaryDirective(
+      title: title ?? this.title,
+      subtitle: subtitle ?? this.subtitle,
+      selected: selected ?? this.selected,
+    );
+  }
 }
 
-//dashboard for flavour profile
+//dashboard with flavour profile
 class FlavourProfile {
   const FlavourProfile({
     required this.label,
@@ -41,4 +71,19 @@ class FlavourProfile {
   final String description;
   final String iconKey;
   final bool selected;
+
+  //selected state
+  FlavourProfile copyWith({
+    String? label,
+    String? description,
+    String? iconKey,
+    bool? selected,
+  }) {
+    return FlavourProfile(
+      label: label ?? this.label,
+      description: description ?? this.description,
+      iconKey: iconKey ?? this.iconKey,
+      selected: selected ?? this.selected,
+    );
+  }
 }

--- a/frontend/lib/features/preference/providers/preference_provider.dart
+++ b/frontend/lib/features/preference/providers/preference_provider.dart
@@ -1,4 +1,4 @@
-// Holds the user's preference profile (dietary restrictions, cuisines, etc.).
+// Holds the user's preference profile state.
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/constants/app_config.dart';
@@ -7,7 +7,7 @@ import '../repositories/api_preference_repository.dart';
 import '../repositories/mock_preference_repository.dart';
 import '../repositories/preference_repository.dart';
 
-//selects mock/API repo
+//select mock/API
 final preferenceRepositoryProvider = Provider<PreferenceRepository>((ref) {
   if (AppConfig.useMockData) {
     return MockPreferenceRepository();
@@ -16,8 +16,117 @@ final preferenceRepositoryProvider = Provider<PreferenceRepository>((ref) {
   return ApiPreferenceRepository();
 });
 
-//exposes preference profile data
-final userPreferencesProvider = FutureProvider<UserPreferences>((ref) {
-  final repository = ref.watch(preferenceRepositoryProvider);
-  return repository.getUserPreferences();
-});
+//editable preference profile
+final userPreferencesProvider =
+    AsyncNotifierProvider<UserPreferencesNotifier, UserPreferences>(
+  UserPreferencesNotifier.new,
+);
+
+class UserPreferencesNotifier extends AsyncNotifier<UserPreferences> {
+  late final PreferenceRepository _repository;
+
+  @override
+  Future<UserPreferences> build() {
+    _repository = ref.watch(preferenceRepositoryProvider);
+    return _repository.getUserPreferences();
+  }
+
+  //dietary directive
+  void toggleDietaryDirective(String title) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    final updatedDirectives = current.dietaryDirectives.map((directive) {
+      if (directive.title != title) return directive;
+      return directive.copyWith(selected: !directive.selected);
+    }).toList();
+
+    state = AsyncData(
+      current.copyWith(dietaryDirectives: updatedDirectives),
+    );
+  }
+
+  //allergies
+  void selectAllergy(String allergy) {
+    final current = state.valueOrNull;
+    if (current == null || current.selectedAllergies.contains(allergy)) return;
+
+    state = AsyncData(
+      current.copyWith(
+        selectedAllergies: [...current.selectedAllergies, allergy],
+        availableAllergies:
+            current.availableAllergies.where((item) => item != allergy).toList(),
+      ),
+    );
+  }
+
+  //available allergy
+  void removeAllergy(String allergy) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    state = AsyncData(
+      current.copyWith(
+        selectedAllergies:
+            current.selectedAllergies.where((item) => item != allergy).toList(),
+        availableAllergies: [...current.availableAllergies, allergy],
+      ),
+    );
+  }
+
+  //disliked ingredient
+  void addDislikedIngredient(String ingredient) {
+    final current = state.valueOrNull;
+    final cleanedIngredient = ingredient.trim().toUpperCase();
+
+    if (current == null ||
+        cleanedIngredient.isEmpty ||
+        current.dislikedIngredients.contains(cleanedIngredient)) {
+      return;
+    }
+
+    state = AsyncData(
+      current.copyWith(
+        dislikedIngredients: [
+          ...current.dislikedIngredients,
+          cleanedIngredient,
+        ],
+      ),
+    );
+  }
+
+  //removes disliked ingredient
+  void removeDislikedIngredient(String ingredient) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    state = AsyncData(
+      current.copyWith(
+        dislikedIngredients: current.dislikedIngredients
+            .where((item) => item != ingredient)
+            .toList(),
+      ),
+    );
+  }
+
+  //flavour profile
+  void toggleFlavourProfile(String label) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+
+    final updatedProfiles = current.flavourProfiles.map((profile) {
+      if (profile.label != label) return profile;
+      return profile.copyWith(selected: !profile.selected);
+    }).toList();
+
+    state = AsyncData(
+      current.copyWith(flavourProfiles: updatedProfiles),
+    );
+  }
+
+  //original mock/API data
+  Future<void> resetPreferences() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(_repository.getUserPreferences);
+  }
+}

--- a/frontend/lib/features/preference/screens/preference_screen.dart
+++ b/frontend/lib/features/preference/screens/preference_screen.dart
@@ -15,7 +15,7 @@ import '../widgets/flavour_profile_card.dart';
 import '../widgets/preference_option_card.dart';
 import '../widgets/preference_tag_chip.dart';
 
-//had to put ConsumerWidget to let screen read Riverpod providers 
+//consumer widget lets screen read Riverpod providers
 class PreferenceScreen extends ConsumerWidget {
   const PreferenceScreen({super.key});
 
@@ -24,7 +24,7 @@ class PreferenceScreen extends ConsumerWidget {
     //loads mock/API data
     final preferencesState = ref.watch(userPreferencesProvider);
 
-    //handles the diff states
+    //handles loading, error, and loaded states
     return preferencesState.when(
       loading: () => const Scaffold(
         body: Center(child: CircularProgressIndicator()),
@@ -43,13 +43,30 @@ class PreferenceScreen extends ConsumerWidget {
   }
 }
 
-class _PreferenceContent extends StatelessWidget {
+class _PreferenceContent extends ConsumerStatefulWidget {
   const _PreferenceContent({required this.preferences});
 
   final UserPreferences preferences;
 
   @override
+  ConsumerState<_PreferenceContent> createState() => _PreferenceContentState();
+}
+
+class _PreferenceContentState extends ConsumerState<_PreferenceContent> {
+  final TextEditingController _dislikedIngredientController =
+      TextEditingController();
+
+  @override
+  void dispose() {
+    _dislikedIngredientController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final preferenceNotifier = ref.read(userPreferencesProvider.notifier);
+    final preferences = widget.preferences;
+
     return Scaffold(
       backgroundColor: AppColors.bgLight,
       appBar: AppBar(
@@ -94,7 +111,7 @@ class _PreferenceContent extends StatelessWidget {
             ),
             const SizedBox(height: 32),
 
-            // Dietary selection cards.
+            //dietary restrictions
             const AppSectionHeader(title: 'Dietary Directives'),
             const SizedBox(height: 14),
             ...preferences.dietaryDirectives.map(
@@ -104,13 +121,15 @@ class _PreferenceContent extends StatelessWidget {
                   title: directive.title,
                   subtitle: directive.subtitle,
                   selected: directive.selected,
-                  onTap: () {},
+                  onTap: () => preferenceNotifier.toggleDietaryDirective(
+                    directive.title,
+                  ),
                 ),
               ),
             ),
             const SizedBox(height: 22),
 
-            // Allergy and dislike tags.
+            //allergy and disliked
             const AppSectionHeader(title: 'Critical Allergies'),
             const SizedBox(height: 14),
             Wrap(
@@ -121,13 +140,13 @@ class _PreferenceContent extends StatelessWidget {
                   (allergy) => PreferenceTagChip(
                     label: allergy,
                     selected: true,
-                    onRemove: () {},
+                    onRemove: () => preferenceNotifier.removeAllergy(allergy),
                   ),
                 ),
                 ...preferences.availableAllergies.map(
                   (allergy) => PreferenceTagChip(
                     label: allergy,
-                    onTap: () {},
+                    onTap: () => preferenceNotifier.selectAllergy(allergy),
                   ),
                 ),
               ],
@@ -136,7 +155,9 @@ class _PreferenceContent extends StatelessWidget {
             const AppSectionHeader(title: 'Aversions & Dislikes'),
             const SizedBox(height: 14),
             AppTextField(
+              controller: _dislikedIngredientController,
               hint: 'Add an ingredient...',
+              onSubmitted: (_) => _addDislikedIngredient(preferenceNotifier),
             ),
             const SizedBox(height: 12),
             Wrap(
@@ -147,14 +168,15 @@ class _PreferenceContent extends StatelessWidget {
                     (ingredient) => PreferenceTagChip(
                       label: ingredient,
                       selected: true,
-                      onRemove: () {},
+                      onRemove: () => preferenceNotifier
+                          .removeDislikedIngredient(ingredient),
                     ),
                   )
                   .toList(),
             ),
             const SizedBox(height: 28),
 
-            // Cuisine preference cards.
+            //cuisine preference
             const AppSectionHeader(title: 'Flavour Profiles'),
             const SizedBox(height: 16),
             ...preferences.flavourProfiles.map(
@@ -165,7 +187,9 @@ class _PreferenceContent extends StatelessWidget {
                   description: profile.description,
                   icon: _iconForFlavourProfile(profile.iconKey),
                   selected: profile.selected,
-                  onTap: () {},
+                  onTap: () => preferenceNotifier.toggleFlavourProfile(
+                    profile.label,
+                  ),
                 ),
               ),
             ),
@@ -177,16 +201,23 @@ class _PreferenceContent extends StatelessWidget {
             const SizedBox(height: 14),
             AppButton(
               label: 'Reset All Directives',
-              onPressed: () {},
+              onPressed: preferenceNotifier.resetPreferences,
             ),
           ],
         ),
       ),
     );
   }
+
+  void _addDislikedIngredient(UserPreferencesNotifier preferenceNotifier) {
+    preferenceNotifier.addDislikedIngredient(
+      _dislikedIngredientController.text,
+    );
+    _dislikedIngredientController.clear();
+  }
 }
 
-// Maps mock/API icon keys to visual icons.
+//maps mock/API icon keys to visual icons
 IconData _iconForFlavourProfile(String iconKey) {
   return switch (iconKey) {
     'mediterranean' => Icons.local_florist_outlined,

--- a/frontend/test/features/pantry/providers/pantry_provider_test.dart
+++ b/frontend/test/features/pantry/providers/pantry_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mealchemy/features/pantry/providers/pantry_provider.dart';
 import 'package:mealchemy/features/pantry/repositories/mock_pantry_repository.dart';
+import 'package:mealchemy/features/pantry/widgets/pantry_item_card.dart';
 
 void main() {
   test('pantryRepositoryProvider uses mock repository', () {
@@ -27,5 +28,82 @@ void main() {
     expect(filters.first.label, 'All');
     expect(ingredients.first.name, 'Chicken Breast');
     expect(categories, contains('produce'));
+  });
+
+  test('selectFilter updates selected pantry filter', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(pantryStateProvider.future);
+
+    final notifier = container.read(pantryStateProvider.notifier);
+    notifier.selectFilter('Dairy');
+
+    final pantryState = container.read(pantryStateProvider).value!;
+
+    expect(pantryState.selectedFilter, 'Dairy');
+  });
+
+  test('updateSearchQuery trims and stores query', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(pantryStateProvider.future);
+
+    final notifier = container.read(pantryStateProvider.notifier);
+    notifier.updateSearchQuery('  milk  ');
+
+    final pantryState = container.read(pantryStateProvider).value!;
+
+    expect(pantryState.searchQuery, 'milk');
+  });
+
+  test('clearSearch resets search query', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(pantryStateProvider.future);
+
+    final notifier = container.read(pantryStateProvider.notifier);
+    notifier.updateSearchQuery('salmon');
+    notifier.clearSearch();
+
+    final pantryState = container.read(pantryStateProvider).value!;
+
+    expect(pantryState.searchQuery, isEmpty);
+  });
+
+  test('markOutOfStock changes ingredient status to expired', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(pantryStateProvider.future);
+
+    final notifier = container.read(pantryStateProvider.notifier);
+    notifier.markOutOfStock('Chicken Breast');
+
+    final pantryState = container.read(pantryStateProvider).value!;
+    final ingredient = pantryState.ingredients.firstWhere(
+      (item) => item.name == 'Chicken Breast',
+    );
+
+    expect(ingredient.status, PantryItemStatus.expired);
+  });
+
+  test('removeIngredient removes ingredient from local pantry list', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(pantryStateProvider.future);
+
+    final notifier = container.read(pantryStateProvider.notifier);
+    notifier.removeIngredient('Chicken Breast');
+
+    final pantryState = container.read(pantryStateProvider).value!;
+
+    expect(
+      pantryState.ingredients.any((item) => item.name == 'Chicken Breast'),
+      isFalse,
+    );
   });
 }

--- a/frontend/test/features/pantry/providers/pantry_provider_test.dart
+++ b/frontend/test/features/pantry/providers/pantry_provider_test.dart
@@ -106,4 +106,29 @@ void main() {
       isFalse,
     );
   });
+
+  test('addIngredient adds manual ingredient to local pantry list', () async {
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+
+  await container.read(pantryStateProvider.future);
+
+  final notifier = container.read(pantryStateProvider.notifier);
+  notifier.addIngredient(
+    name: 'Brown Rice',
+    quantity: '500',
+    unit: 'g',
+    category: 'grains',
+    isOutOfStock: false,
+  );
+
+  final pantryState = container.read(pantryStateProvider).value!;
+  final ingredient = pantryState.ingredients.firstWhere(
+    (item) => item.name == 'Brown Rice',
+  );
+
+  expect(ingredient.details, '500g • Manual entry');
+  expect(ingredient.category, 'Other');
+  expect(ingredient.status, PantryItemStatus.fresh);
+});
 }

--- a/frontend/test/features/pantry/screens/add_ingredient_screen_test.dart
+++ b/frontend/test/features/pantry/screens/add_ingredient_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mealchemy/core/shared_widgets/atoms/app_button.dart';
 import 'package:mealchemy/features/pantry/screens/add_ingredient_screen.dart';
 
 void main() {
@@ -9,9 +10,15 @@ void main() {
     GoogleFonts.config.allowRuntimeFetching = false;
   });
 
-  testWidgets('AddIngredientScreen renders manual ingredient form', (
-    tester,
-  ) async {
+  Future<void> pumpAddIngredientScreen(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1;
+
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
     await tester.pumpWidget(
       //need provider scope because screen reads Riverpod providers
       const ProviderScope(
@@ -23,10 +30,50 @@ void main() {
 
     //waits for mock data to load
     await tester.pumpAndSettle();
+  }
+
+  testWidgets('AddIngredientScreen renders manual ingredient form', (
+    tester,
+  ) async {
+    await pumpAddIngredientScreen(tester);
 
     expect(find.text('Add Ingredient\nManually'), findsOneWidget);
     expect(find.text('Ingredient Details'), findsOneWidget);
     expect(find.text('Ingredient name'), findsOneWidget);
     expect(find.text('Quantity'), findsWidgets);
+  });
+
+  testWidgets('AddIngredientScreen validates required fields on save', (
+    tester,
+  ) async {
+    await pumpAddIngredientScreen(tester);
+
+    // First AppButton is the save action.
+    await tester.tap(find.byType(AppButton).first);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Ingredient name is required.', skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Quantity and unit are required.', skipOffstage: false),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('AddIngredientScreen updates category and stock controls', (
+    tester,
+  ) async {
+    await pumpAddIngredientScreen(tester);
+
+    await tester.tap(find.text('DAIRY'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Mark as out of stock'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('DAIRY'), findsOneWidget);
+    expect(find.text('Mark as out of stock'), findsOneWidget);
   });
 }

--- a/frontend/test/features/pantry/screens/pantry_test.dart
+++ b/frontend/test/features/pantry/screens/pantry_test.dart
@@ -12,7 +12,6 @@ void main() {
 
   //make sure renders everything
   testWidgets('PantryScreen renders pantry overview', (tester) async {
-    //wrapping screen
     await tester.pumpWidget(
       const ProviderScope(
         child: MaterialApp(
@@ -23,10 +22,49 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    //make sure displays 
     expect(find.text('Pantry'), findsWidgets);
     expect(find.text('Meal Optimization'), findsOneWidget);
     expect(find.text('Proteins'), findsOneWidget);
     expect(find.text('Chicken Breast'), findsOneWidget);
+  });
+
+  testWidgets('PantryScreen filters pantry items by search query', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: PantryScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'milk');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Full Cream Milk'), findsOneWidget);
+    expect(find.text('Chicken Breast'), findsNothing);
+  });
+
+  testWidgets('PantryScreen filters pantry items by category', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: PantryScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final dairyFilter = find.textContaining('Dairy').first;
+    await tester.ensureVisible(dairyFilter);
+    await tester.tap(dairyFilter);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Full Cream Milk'), findsOneWidget);
+    expect(find.text('Chicken Breast'), findsNothing);
   });
 }

--- a/frontend/test/features/preference/providers/preference_provider_test.dart
+++ b/frontend/test/features/preference/providers/preference_provider_test.dart
@@ -8,11 +8,11 @@ void main() {
   test('preferenceRepositoryProvider uses mock repository', () {
     //create Riverpod provider container for isolated testing
     final container = ProviderContainer();
+
     //delete container
     addTearDown(container.dispose);
 
     final repository = container.read(preferenceRepositoryProvider);
-
     //using mock repo
     expect(repository, isA<MockPreferenceRepository>());
   });
@@ -21,9 +21,131 @@ void main() {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
+    //load preference data from provider
     final preferences = await container.read(userPreferencesProvider.future);
 
+    //check mock allergy data exists
     expect(preferences.selectedAllergies, contains('PEANUTS'));
     expect(preferences.flavourProfiles.first.selected, isTrue);
+  });
+
+  test('toggleDietaryDirective updates selected state', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(userPreferencesProvider.future);
+
+    //get notifier instance
+    final notifier = container.read(userPreferencesProvider.notifier);
+    notifier.toggleDietaryDirective('PLANT-BASED / VEGAN');
+
+    final preferences = container.read(userPreferencesProvider).value!;
+
+    //ensure dietary directive selected
+    expect(preferences.dietaryDirectives.first.selected, isTrue);
+  });
+
+  //checks allergy gets moved into selected allergies list
+  test('selectAllergy moves allergy into selected list', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    //wait for provider initialization
+    await container.read(userPreferencesProvider.future);
+
+    final notifier = container.read(userPreferencesProvider.notifier);
+    //select allergy
+    notifier.selectAllergy('SOY');
+
+    final preferences = container.read(userPreferencesProvider).value!;
+
+    expect(preferences.selectedAllergies, contains('SOY'));
+    expect(preferences.availableAllergies, isNot(contains('SOY')));
+  });
+
+  //checks allergy is moved back into available list
+  test('removeAllergy moves allergy back into available list', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(userPreferencesProvider.future);
+
+    final notifier = container.read(userPreferencesProvider.notifier);
+    //remove allergy from list
+    notifier.removeAllergy('PEANUTS');
+
+    final preferences = container.read(userPreferencesProvider).value!;
+
+    expect(preferences.selectedAllergies, isNot(contains('PEANUTS')));
+    expect(preferences.availableAllergies, contains('PEANUTS'));
+  });
+
+  //formatting
+  test('addDislikedIngredient adds uppercase trimmed ingredient', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(userPreferencesProvider.future);
+
+    final notifier = container.read(userPreferencesProvider.notifier);
+    //add with spaces and lowercase
+    notifier.addDislikedIngredient(' mushrooms ');
+
+    final preferences = container.read(userPreferencesProvider).value!;
+
+    //trimmed and changed to uppercase
+    expect(preferences.dislikedIngredients, contains('MUSHROOMS'));
+  });
+
+  //checks disliked ingredient removal
+  test('removeDislikedIngredient removes ingredient', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(userPreferencesProvider.future);
+
+    final notifier = container.read(userPreferencesProvider.notifier);
+    notifier.removeDislikedIngredient('CILANTRO');
+
+    //read updated preferences
+    final preferences = container.read(userPreferencesProvider).value!;
+
+    expect(preferences.dislikedIngredients, isNot(contains('CILANTRO')));
+  });
+
+  //flavour profile selection
+  test('toggleFlavourProfile updates selected state', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(userPreferencesProvider.future);
+
+    final notifier = container.read(userPreferencesProvider.notifier);
+    notifier.toggleFlavourProfile('Asian Fusion');
+
+    final preferences = container.read(userPreferencesProvider).value!;
+    final asianProfile = preferences.flavourProfiles.firstWhere(
+      (profile) => profile.label == 'Asian Fusion',
+    );
+
+    expect(asianProfile.selected, isTrue);
+  });
+
+  //resets back to original data
+  test('resetPreferences restores original mock data', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(userPreferencesProvider.future);
+
+    final notifier = container.read(userPreferencesProvider.notifier);
+    //modify before reset
+    notifier.selectAllergy('SOY');
+    await notifier.resetPreferences();
+
+    final preferences = container.read(userPreferencesProvider).value!;
+
+    expect(preferences.selectedAllergies, isNot(contains('SOY')));
+    expect(preferences.selectedAllergies, contains('PEANUTS'));
   });
 }


### PR DESCRIPTION
What changed:

Preference Profile:
Added local interaction state for dietary directives, allergy chips, disliked ingredients, and flavour profile cards
Added reset behaviour to restore provider-backed mock defaults
Updated PreferenceScreen to call the preference notifier instead of using no-op handlers

Pantry:
Added local interaction state for search, category filtering, out-of-stock marking, and ingredient removal
Updated PantryScreen to render filtered provider state
Added empty result messaging for search/filter combinations

Add Ingredient:
Added local form state for ingredient name, category, quantity, unit, price, and stock status
Added basic validation for required fields
Added local save behaviour that inserts a manual ingredient into pantry state and returns to Pantry

Tests:
Added/updated provider and widget tests for preference interactions, pantry interactions, and add ingredient form behaviour

Notes:
This is still frontend-local state using mock/provider data
Backend/API integration is intentionally not included yet because endpoints are still in progress

Next steps
- Connect Preference Profile to the real preferences endpoint once backend is ready
- Connect Pantry list and Add Ingredient form to the real pantry endpoints
- Replace local mock save/update behaviour with repository API calls
- Add loading, success, and error feedback for real network requests
- Confirm final request/response shapes with backend for PUT preferences and pantry create/update/delete
- Expand tests around API repositories once backend integration begins