### PR TITLE
Fix/vault recipe screen navigation/megan azmanov

### DIFF
--- a/frontend/lib/features/vault/screens/vault_screen.dart
+++ b/frontend/lib/features/vault/screens/vault_screen.dart
@@ -28,7 +28,7 @@ class VaultScreen extends ConsumerWidget {
         onRouteSelected: (route) => context.go(route),
       ),
       floatingActionButton: FloatingActionButton(
-         onPressed: () => context.go(AppRoutes.addRecipe),
+         onPressed: () => context.push(AppRoutes.addRecipe),
         backgroundColor: AppColors.primary,
         foregroundColor: AppColors.textDark,
         child: const Icon(Icons.add),

--- a/frontend/lib/features/vault/widgets/vault_folder_card.dart
+++ b/frontend/lib/features/vault/widgets/vault_folder_card.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../core/routes/app_routes.dart';
 import '../../../core/theme/app_colours.dart';
 import '../../../core/theme/app_typography.dart';
 import 'package:mealchemy/features/recipe/models/recipe.dart';
@@ -263,7 +262,7 @@ class _FolderRecipeRow extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: InkWell(
-        onTap: () => context.go(AppRoutes.login, extra: recipe),
+        onTap: () => context.push('/recipe/${recipe.recipeId}'),
         borderRadius: BorderRadius.circular(10),
         child: Container(
           padding: const EdgeInsets.all(10),

--- a/frontend/lib/features/vault/widgets/vault_quick_strip.dart
+++ b/frontend/lib/features/vault/widgets/vault_quick_strip.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import '../../../core/theme/app_colours.dart';
 import '../../../core/theme/app_typography.dart';
 import 'package:mealchemy/features/recipe/models/recipe.dart';
@@ -37,8 +38,10 @@ class _QuickRecipeThumbnail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
+    return GestureDetector(
+      onTap: () => context.push('/recipe/${recipe.recipeId}'),
+      child: Column(
+        children: [
         Container(
           width: 64,
           height: 64,
@@ -83,7 +86,8 @@ class _QuickRecipeThumbnail extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
         ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/frontend/macos/Runner/DebugProfile.entitlements
+++ b/frontend/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/frontend/macos/Runner/Release.entitlements
+++ b/frontend/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/frontend/test/features/vault/screens/vault_test.dart
+++ b/frontend/test/features/vault/screens/vault_test.dart
@@ -42,6 +42,10 @@ void main() {
               path: '/recipe/add',
               builder: (context, state) => const Scaffold(body: Text('Add Recipe')),
             ),
+            GoRoute(
+              path: '/recipe/:id',
+              builder: (context, state) => const Scaffold(body: Text('Recipe Detail')),
+            ),
           ],
         ),
       ),
@@ -96,6 +100,15 @@ void main() {
       await tester.pumpWidget(buildWidget());
       await tester.pump(const Duration(milliseconds: 600));
       expect(find.byType(VaultQuickStrip), findsOneWidget);
+    });
+
+    //Tapping floating action button navigates to add recipe screen
+    testWidgets('tapping FAB navigates to add recipe', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+      expect(find.text('Add Recipe'), findsOneWidget);
     });
   });
 }

--- a/frontend/test/features/vault/widgets/vault_folder_card_test.dart
+++ b/frontend/test/features/vault/widgets/vault_folder_card_test.dart
@@ -36,6 +36,10 @@ void main() {
               path: '/login',
               builder: (context, state) => const Scaffold(body: Text('Login')),
             ),
+            GoRoute(
+              path: '/recipe/:id',
+              builder: (context, state) => const Scaffold(body: Text('Recipe Detail')),
+            ),
           ],
         ),
       ),
@@ -66,6 +70,19 @@ void main() {
       await tester.tap(find.byType(InkWell).first);
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byIcon(Icons.folder_open_rounded), findsOneWidget);
+    });
+
+    //Tapping a recipe row inside an expanded folder navigates to recipe detail
+    testWidgets('tapping a recipe row navigates to recipe detail', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+      // expand the folder first
+      await tester.tap(find.byType(InkWell).first);
+      await tester.pumpAndSettle();
+      // tap the first recipe row (index 1, index 0 is the folder header)
+      await tester.tap(find.byType(InkWell).at(1));
+      await tester.pumpAndSettle();
+      expect(find.text('Recipe Detail'), findsOneWidget);
     });
   });
 }

--- a/frontend/test/features/vault/widgets/vault_quick_strip_test.dart
+++ b/frontend/test/features/vault/widgets/vault_quick_strip_test.dart
@@ -60,5 +60,15 @@ void main() {
       ]));
       expect(find.byIcon(Icons.restaurant_rounded), findsOneWidget);
     });
+
+    //Tapping a recipe thumbnail navigates to the recipe detail screen
+    testWidgets('tapping a thumbnail navigates to recipe detail', (tester) async {
+      await tester.pumpWidget(buildWidget([
+        const Recipe(recipeId: 1, title: 'Pasta Vera', cuisineType: 'Italian'),
+      ]));
+      await tester.tap(find.byType(GestureDetector).first);
+      await tester.pumpAndSettle();
+      expect(find.text('Recipe Detail'), findsOneWidget);
+    });
   });
 }

--- a/frontend/test/features/vault/widgets/vault_quick_strip_test.dart
+++ b/frontend/test/features/vault/widgets/vault_quick_strip_test.dart
@@ -1,15 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mealchemy/core/theme/app_theme.dart';
 import 'package:mealchemy/features/vault/widgets/vault_quick_strip.dart';
 import 'package:mealchemy/features/recipe/models/recipe.dart';
 
 void main() {
   Widget buildWidget(List<Recipe> recipes) {
-    return MaterialApp(
+    return MaterialApp.router(
       theme: AppTheme.light,
-      home: Scaffold(
-        body: VaultQuickStrip(recipes: recipes),
+      routerConfig: GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: VaultQuickStrip(recipes: recipes),
+            ),
+          ),
+          GoRoute(
+            path: '/recipe/:id',
+            builder: (context, state) => const Scaffold(body: Text('Recipe Detail')),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
- Edit to  vault_quick_strip.dart
- The _QuickRecipeThumbnail widget rendered the circle add label but had no tap handler. 
- Wrapped the Column in a GestureDetector with context.push and added the go_router import.
- push (instead of go) keeps the vault screen in the back stack so the back button works.

- Fixed tapping recipe goes to login

- Add recipe back button didn't work.
- Changed it to context.push so the vault screen stays underneath.

- MacOs font failing to load. 
- Both DebugProfile.entitlements and Release.entitlements were missing com.apple.security.network.client. macOS sandboxes desktop Flutter apps, and without that entitlement all outbound HTTPS is blocked, which is why every google_fonts fetch was failing.

Test: 
vault_quick_strip_test.dart
-  was using plain MaterialApp instead of MaterialApp.router. had to change to correspond to context.push().  go_router requires a real router in scope.